### PR TITLE
Add client-side hooks to prevent bad code being pushed

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run test:ci
+npm run  build

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "eodhp-resource-catalogue",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.7.4",
         "leaflet": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:rules": "eslint --print-config rules > eslint-rules.json",
     "lint:css": "stylelint '**/*.{css,scss}'",
     "lint:css:fix": "stylelint '**/*.{css,scss}' --fix",
+    "postinstall": "npx husky install .husky",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Added `husky](https://typicode.github.io/husky/), a tool to protect developers from themselves, you can configure client-side `GIT hooks` in the repo itself so they are shared. The hooks can then run tests, linting etc prior to commits, pushes etc. If the script fails, then the commit/push etc is not completed.

I have added the `pre-push` hook to run tests, compile TypeScrip and lint SCSS and build the app, so the code cannot be pushed to GitHub, unless it works and all tests pass.

IssueID EODHP-615