### PR TITLE
Use appropriate cache headers when serving the built app

### DIFF
--- a/.github/workflows/push-to-aws-s3.yaml
+++ b/.github/workflows/push-to-aws-s3.yaml
@@ -63,4 +63,4 @@ jobs:
       - name: Sync files to S3 bucket
         run: |
           echo ls
-          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/resource-catalogue/$IMAGE_TAG --recursive $(if [[ "${GITHUB_REF_TYPE}" = "branch" ]]; then echo --cache-control no-cache; fi)
+          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/resource-catalogue/$IMAGE_TAG --recursive $(if [[ "${GITHUB_REF_TYPE}" = "branch" ]]; then echo --cache-control no-cache; else echo --cache-control max-age=31536000; fi)

--- a/.github/workflows/push-to-aws-s3.yaml
+++ b/.github/workflows/push-to-aws-s3.yaml
@@ -63,4 +63,4 @@ jobs:
       - name: Sync files to S3 bucket
         run: |
           echo ls
-          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/resource-catalogue/$IMAGE_TAG --recursive
+          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/resource-catalogue/$IMAGE_TAG --recursive $(if [[ "${GITHUB_REF_TYPE}" = "branch" ]]; then echo --cache-control no-cache; fi)


### PR DESCRIPTION
This sets `Cache-Control: no-cache` in S3 when we're building from a branch and `Cache-Control: max-age=<1 year in seconds>` when we build from a tag. This will stop CloudFront caching our dev builds whilst still following good practice for production builds (which have unique names due to the tag being in the URL).
