### PR TITLE
Commercial data Forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,23 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@hookform/resolvers": "^3.9.0",
+        "@turf/turf": "^7.1.0",
         "axios": "^1.7.4",
+        "date-fns": "^3.6.0",
         "leaflet": "^1.9.4",
         "optionator": "^0.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-draggable": "^4.4.6",
+        "react-hook-form": "^7.53.0",
         "react-icons": "^5.2.1",
         "react-responsive-pagination": "^2.6.0",
         "react-router-dom": "^6.21.1",
+        "react-select": "^5.8.0",
         "react-tooltip": "^5.28.0",
-        "react-use": "^17.5.1"
+        "react-use": "^17.5.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@axe-core/react": "^4.9.1",
@@ -100,7 +106,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
       "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
@@ -161,7 +166,6 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
       "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -201,7 +205,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -254,7 +257,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
       "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -263,7 +265,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -294,7 +295,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
@@ -309,7 +309,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -321,7 +320,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -335,7 +333,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -343,14 +340,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -359,7 +354,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -368,7 +362,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -380,7 +373,6 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
       "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.25.6"
       },
@@ -436,7 +428,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
       "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/parser": "^7.25.0",
@@ -450,7 +441,6 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
       "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/generator": "^7.25.6",
@@ -468,7 +458,6 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
       "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
@@ -611,6 +600,132 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+      "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.2.0",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.13.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.13.3",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+      "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/cache": "^11.13.0",
+        "@emotion/serialize": "^1.3.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.1.tgz",
+      "integrity": "sha512-dEPNKzBPU+vFPGa+z3axPRn8XVDetYORmDC0wAiej+TNcOZE70ZMJa0X7JdeoM6q/nWTMZeLpN/fTnD9o8MQBA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+      "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
+      "integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1107,6 +1222,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
       "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
+      "integrity": "sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1267,7 +1390,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1281,7 +1403,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1290,7 +1411,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1304,23 +1424,22 @@
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
-      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.35.0.tgz",
+      "integrity": "sha512-f5cHyIvm4m4g1I5x9EH1etGx0puaU0OaX2szqGRVBVgUC6aMASlOI5hbpe7tJ9l4/VWjCUu5OMraCazLZGI24A==",
       "dev": true,
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/logger": "^0.3.0",
         "@open-draft/until": "^2.0.0",
         "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
+        "outvariant": "^1.4.3",
         "strict-event-emitter": "^0.5.1"
       },
       "engines": {
@@ -2176,6 +2295,1958 @@
         "eslint": "^8.49.0"
       }
     },
+    "node_modules/@turf/along": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.1.0.tgz",
+      "integrity": "sha512-WLgBZJ/B6CcASF6WL7M+COtHlVP0hBrMbrtKyF7KBlicwRuijJZXDtEQA5oLgr+k1b2HqGN+UqH2A0/E719enQ==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.1.0.tgz",
+      "integrity": "sha512-YMHEV/YrARsWgWoQuXEWrQMsvB8z67nTMw2eiLZ883V7jwkhWQGvCW6W+/mGgsWQdHppjCZNcKryryhD2GRWVA==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.1.0.tgz",
+      "integrity": "sha512-w91FEe02/mQfMPRX2pXua48scFuKJ2dSVMF2XmJ6+BJfFiCPxp95I3+Org8+ZsYv93CDNKbf0oLNEPnuQdgs2g==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.1.0.tgz",
+      "integrity": "sha512-PdWPz9tW86PD78vSZj2fiRaB8JhUHy6piSa/QXb83lucxPK+HTAdzlDQMTKj5okRCU8Ox/25IR2ep9T8NdopRA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.1.0.tgz",
+      "integrity": "sha512-PhZubKCzF/afwStUzODqOJluiCbCw244lCtVhXA9F+Pgkhvk8KvbFdgpPquOZ45OwuktrchSB28BrBkSBiadHw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.1.0.tgz",
+      "integrity": "sha512-fvZB09ErCZOVlWVDop836hmpKaGUmfXnR9naMhS73A/8nn4M3hELbQtMv2R8gXj7UakXCuxS/i9erdpDFZ2O+g==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.1.0.tgz",
+      "integrity": "sha512-X5lackrZ6FW+YhgjWxwVFRgWD1j4xm4t5VvE6EE6v/1PVaHQ5OCjf6u1oaLx5LSG+gaHUhjTlAHrn9MYPFaeTA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.1.0.tgz",
+      "integrity": "sha512-bhBY70bcVYJEosuW7B/TFtnE5rmPTTpxmJvljhGC0eyM84oNVv7apDBuseb5KdlTOOBIvdD9nIE4qV8lmplp6w==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.1.0.tgz",
+      "integrity": "sha512-H5DYno+gHwZx+VaiC8DUBZXZQlxYecdSvqCfCACWi1uMsKvlht/O+xy65hz2P57lk2smlcV+1ETFVxJlEZduYg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.1.0.tgz",
+      "integrity": "sha512-IFCN25DI+hvngxIsv4+MPuRJQRl/Lz/xnZgpH82leCn4Jqn5wW7KqKFMz7G4GoKK+93cK5/6ioAxY7hVWBXxJw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.1.0.tgz",
+      "integrity": "sha512-ldy4j1/RVChYTYjEb4wWaE/JyF1jA87WpsB4eVLic6OcAYJGs7POF1kfKbcdkJJiRBmhI3CXNA+u+m9y4Z/j3g==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.1.0.tgz",
+      "integrity": "sha512-LK8UM3AENycuGinLCDaL0QSznGMnD0XsjFDGnY4KehshiL5Zd8ZsPyKmHOPygUJT9DWeH69iLx459lOc+5Vj2w==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/polygon-to-line": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.1.0.tgz",
+      "integrity": "sha512-JapOG03kOCoGeYMWgTQjEifhr1nUoK4Os2cX0iC5X9kvZF4qCHeruX8/rffBQDx7PDKQKusSTXq8B1ISFi0hOw==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/polygon-to-line": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.1.0.tgz",
+      "integrity": "sha512-deghtFMApc7fNsdXtZdgYR4gsU+TVfowcv666nrvZbPPsXL6NTYGBhDFmYXsJ8gPTCGT9uT0WXppdgT8diWOxA==",
+      "dependencies": {
+        "@turf/clean-coords": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.1.0.tgz",
+      "integrity": "sha512-gpksWbb0RT+Z3nfqRfoACY3KEFyv2BPaxJ3L76PH67DhHZviq3Nfg85KYbpuhS64FSm+9tXe4IaKn6EjbHo20g==",
+      "dependencies": {
+        "@turf/boolean-disjoint": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.1.0.tgz",
+      "integrity": "sha512-mJRN0X8JiPm8eDZk5sLvIrsP03A2GId6ijx4VgSE1AvHwV6qB561KlUbWxga2AScocIfv/y/qd2OCs+/TQSZcg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/line-overlap": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.1.0.tgz",
+      "integrity": "sha512-tA84Oux0X91CxUc6c/lZph5W9wUZGNT4fxFOg5Gp1IMTSwtxSYL1LMvKsr/VmMnwdOUkNcqAgU06+t4wBLtDfg==",
+      "dependencies": {
+        "@turf/clean-coords": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/line-segment": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.1.0.tgz",
+      "integrity": "sha512-mprVsyIQ+ijWTZwbnO4Jhxu94ZW2M2CheqLiRTsGJy0Ooay9v6Av5/Nl3/Gst7ZVXxPqMeMaFYkSzcTc87AKew==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.1.0.tgz",
+      "integrity": "sha512-Kd83EjeTyY4kVMAhcW3Lb8aChwh24BUIhmpE9Or8M+ETNsFGzn9M7qtIySJHLRzKAL3letvWSKXKQPuK1AhAzg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.1.0.tgz",
+      "integrity": "sha512-qN4LCs3RfVtNAAdn5GpsUFBqoZyAaK9UzSnGSh67GP9sy5M8MEHwM/HAJ5zGWJqQADrczI3U6BRWGLcGfGSz3Q==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.1.0.tgz",
+      "integrity": "sha512-zq1QCfQEyn+piHlvxxDifjmsJn2xl53i4mnKFYdMQI/i09XiX+Fi/MVM3i2hf3D5AsEPsud8Tk7C7rWNCm4nVw==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-crosses": "^7.1.0",
+        "@turf/boolean-disjoint": "^7.1.0",
+        "@turf/boolean-overlap": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.1.0.tgz",
+      "integrity": "sha512-pgXgKCzYHssADQ1nClB1Q9aWI/dE1elm2jy3B5X59XdoFXKrKDZA+gCHYOYgp2NGO/txzVfl3UKvnxIj54Fa4w==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.1.0.tgz",
+      "integrity": "sha512-QM3JiCMYA19k5ouO8wJtvICX3Y8XntxVpDfHSKhFFidZcCkMTR2PWWOpwS6EoL3t75rSKw/FOLIPLZGtIu963w==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/center": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "^7.1.0",
+        "@turf/projection": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.1.0.tgz",
+      "integrity": "sha512-p9AvBMwNZmRg65kU27cGKHAUQnEcdz8Y7f/i5DvaMfm4e8zmawr+hzPKXaUpUfiTyLs8Xt2W9vlOmNGyH+6X3w==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.1.0.tgz",
+      "integrity": "sha512-NQZB1LUVsyAD+p0+D4huzX2XVnfVx1yEEI9EX602THmi+g+nkge4SK9OMV11ov/Tv8JJ6aVNVPo/cy1vm/LCIQ==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.1.0.tgz",
+      "integrity": "sha512-jx4/Ql5+v41Cd0J/gseNCUbLTzWUT2LUaiXn8eFWDrvmEgqHIx7KJcGcJd5HzV+9zJwng4AXxyh5NMvUR0NjwA==",
+      "dependencies": {
+        "@turf/center-mean": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.1.0.tgz",
+      "integrity": "sha512-j38oBlj7LBoCjZbrIo8EoHVGhk7UQmMLQ1fe8ZPAF9pd05XEL1qxyHKZKdQ/deGISiaEhXCyfLNrKAHAuy25RA==",
+      "dependencies": {
+        "@turf/centroid": "^7.1.0",
+        "@turf/convex": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.1.0.tgz",
+      "integrity": "sha512-1Y1b2l+ZB1CZ+ITjUCsGqC4/tSjwm/R4OUfDztVqyyCq/VvezkLmTNqvXTGXgfP0GXkpv68iCfxF5M7QdM5pJQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.1.0.tgz",
+      "integrity": "sha512-6qhF1drjwH0Dg3ZB9om1JkWTJfAqBcbtIrAj5UPlrAeHP87hGoCO2ZEsFEAL9Q18vntpivT89Uho/nqQUjJhYw==",
+      "dependencies": {
+        "@turf/destination": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.1.0.tgz",
+      "integrity": "sha512-q1U8UbRVL5cRdwOlNjD8mad8pWjFGe0s4ihg1pSiVNq7i47WASJ3k20yZiUFvuAkyNjV0rZ/A7Jd7WzjcierFg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.1.0.tgz",
+      "integrity": "sha512-5R9qeWvL7FDdBIbEemd0eCzOStr09oburDvJ1hRiPCFX6rPgzcZBQ0gDmZzoF4AFcNLb5IwknbLZjVLaUGWtFA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.1.0.tgz",
+      "integrity": "sha512-7CY3Ai+5V6q2O9/IgqLpJQrmrTy7aUJjTW1iRan8Tz3WixvxyJHeS3iyRy8Oc0046chQIaHLtyTgKVt2QdsPSA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.1.0.tgz",
+      "integrity": "sha512-BmrBTOEaKN5FIED6b3yb3V3ejfK0A2Q3pT9/ji3mcRLJiBaRGeiN5V6gtGXe7PeMYdoqhHykU5Ye2uUtREWRdQ==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@turf/clusters-dbscan/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.1.0.tgz",
+      "integrity": "sha512-M8cCqR6iE1jDSUF/UU9QdPUFrobZS2fo59TfF1IRHZ2G1EjbcK4GzZcUfmQS6DZraGudYutpMYIuNdm1dPMqdQ==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.1.0.tgz",
+      "integrity": "sha512-6indMWLiKeBh4AsioNeFeFnO0k9U5CBsWAFEje6tOEFI4c+P7LF9mNA9z91H8KkrhegR9XNO5Vm2rmdY63aYXw==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@turf/collect/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.1.0.tgz",
+      "integrity": "sha512-Xl7bGKKjgzIq2T/IemS6qnIykyuxU6cMxKtz+qLeWJGoNww/BllwxXePSV+dWRPXZTFFj96KIhBXAW0aUjAQKQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.1.0.tgz",
+      "integrity": "sha512-aSid53gYRee4Tjc4pfeI3KI+RoBUnL/hRMilxIPduagTgZZS+cvvk01OQWBKm5UTVfHRGuy0XIqnK8y9RFinDQ==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/tin": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.1.0.tgz",
+      "integrity": "sha512-w9fUMZYE36bLrEWEj7L7aVMCB7NBtr2o8G+avRvUIwF4DPqbtcjlcZE9EEBfq44uYdn+/Pke6Iq42T/zyD/cpg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.1.0.tgz",
+      "integrity": "sha512-97XuvB0iaAiMg86hrnZ529WwP44TQAA9mmI5PMlchACiA4LFrEtWjjDzvO6234coieoqhrw6dZYcJvd5O2PwrQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.1.0.tgz",
+      "integrity": "sha512-+JVzdskICQ8ULKQ9CpWUM5kBvoXxN4CO78Ez/Ki3/7NXl7+HM/nb12B0OyM8hkJchpb8TsOi0YwyJiKMqEpTBA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "polygon-clipping": "^0.15.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.1.0.tgz",
+      "integrity": "sha512-fyOnCSYVUZ8SF9kt9ROnQYlkJTE0hpWSoWwbMZQCAR7oVZVPiuPq7eIbzTP+k5jzEAnofsqoGs5qVDTjHcWMiw==",
+      "dependencies": {
+        "@turf/flatten": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "polygon-clipping": "^0.15.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.1.0.tgz",
+      "integrity": "sha512-hhNHhxCHB3ddzAGCNY4BtE29OZh+DAJPvUapQz+wOjISnlwvMcwLKvslgHWSYF536QDVe/93FEU2q67+CsZTPA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.1.0.tgz",
+      "integrity": "sha512-8m6s4y8Yyt6r3itf44yAJjXC+62UkrkhOpskIfaE0lHcBcvZz9wjboHoBf3bS4l/42E4StcanbFZdjOpODAdZw==",
+      "dependencies": {
+        "@turf/centroid": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.1.0.tgz",
+      "integrity": "sha512-AfOahUmStDExWGPg8ZWxxkgom+fdJs7Mn9DzZH+fV/uZ+je1bLQpbPCUu9/ev6u/HhbYGl4VAL/CeQzjOyy6LQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/rhumb-destination": "^7.1.0",
+        "@turf/transform-rotate": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.1.0.tgz",
+      "integrity": "sha512-WeLQse9wuxsxhzSqrJA6Ha7rLWnLKgdKY9cfxmJKHSpgqcJyNk60m7+T3UpI/nkGwpfbpeyB3EGC1EWPbxiDUg==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/bbox-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.1.0.tgz",
+      "integrity": "sha512-To+GUbU6HtcHZ8S0w/dw1EbdQIOCXALTr6Ug5/IFg8hIBMJelDpVr3Smwy8uqhDRFinY2eprBwQnDPcd10eCqA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.1.0.tgz",
+      "integrity": "sha512-Kb23pqEarcLsdBqnQcK0qTrSMiWNTVb9tOFrNlZc66DIhDLAdpOKG4eqk00CMoUzWTixlnawDgJRqcStRrR4WA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.1.0.tgz",
+      "integrity": "sha512-vac73W8WblzzNFanzWYLBzWDIcqc5xczOrtEO07RDEiKEI3Heo0471Jed3v9W506uuOX6/HAiCjXbRjTLjiLfw==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.1.0.tgz",
+      "integrity": "sha512-j1C7Ohlxa1z644bNOpgibcFGaDLgLXGLOzwF1tfQaP5y7E4PJQUXL0DWIgNb3Ke7gZC05LPHM25a5TRReUfFBQ==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.1.0.tgz",
+      "integrity": "sha512-92q5fqUp5oW+FYekUIrUVR5PZBWbOV6NHKHPIiNahiPvtkpZItbbjoO+tGn5+2i8mxZP9FGOthayJe4V0a1xkg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.1.0.tgz",
+      "integrity": "sha512-I+Apx0smOPkMzaS5HHL44YOxSkSUvrz+wtSIETsDFWWLT2xKNkaaEcYU5MkgSoEfQsj082M7EkOIIpocXlA3kg==",
+      "dependencies": {
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/intersect": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.1.0.tgz",
+      "integrity": "sha512-VWec1OW9gHZLPS3yYkUXAHKMGQuYO4aqh8WCltT7Ym4efrKqkSOE5T+mBqO68QgcL8nY4kiNa8lxwXd0SfXDSA==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/hex-grid": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/point-grid": "^7.1.0",
+        "@turf/square-grid": "^7.1.0",
+        "@turf/triangle-grid": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.1.0.tgz",
+      "integrity": "sha512-T0VhI6yhptX9EoMsuuBETyqV+edyq31SUC8bfuM6kdJ5WwJ0EvUfQoC+3bhMtCOn60lHawrUuGBgW+vCO8KGMg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "polygon-clipping": "^0.15.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.1.0.tgz",
+      "integrity": "sha512-OCLNqkItBYIP1nE9lJGuIUatWGtQ4rhBKAyTfFu0z8npVzGEYzvguEeof8/6LkKmTTEHW53tCjoEhSSzdRh08Q==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.1.0.tgz",
+      "integrity": "sha512-iMLTOP/K5C05AttF4N1WeV+KrY4O5VWW/abO0N86XCWh1OeqmIUgqIBKEmhDzttAqC0UK2YrUfj0lI1Ez1fYZQ==",
+      "dependencies": {
+        "@turf/area": "^7.1.0",
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/explode": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "marchingsquares": "^1.3.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.1.0.tgz",
+      "integrity": "sha512-V6QTHXBT5ZsL3s9ZVBJgHYtz3gCFKqNnQLysNE02LE0fVVqaSao3sFrcpghmdDxf0hBCDK8lZVvyRGO6o32LHQ==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "marchingsquares": "^1.3.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-+nwOKme/aUprsxnLSfr2LylV6eL6T1Tuln+4Hl92uwZ8FrmjDRCH5Bi1LJNVfWCiYgk8+5K+t2zDphWNTsIFDA==",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.1.0.tgz",
+      "integrity": "sha512-KKLYUsyJPU17fODwA81mhHzFYGQYocdbk9NxDPCcdRHvxzM8t95lptkGx/2k/9rXBs1DK7NmyzI4m7zDO0DK7g==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.1.0.tgz",
+      "integrity": "sha512-wUJj9WLKEudG1ngNao2ZwD+Dt6UkvWIbubuJ6lR6FndFDL3iezFhNGy0IXS+0xH9kXi2apiTnM9Vk5+i8BTEvQ==",
+      "dependencies": {
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.1.0.tgz",
+      "integrity": "sha512-9/bM34PozTyJ5FXXPAzl/j0RpcTImgMFJZ0WhH0pZZEZRum6P0rJnENt2E2qI441zeozQ9H6X5DCiJogDmRUEw==",
+      "dependencies": {
+        "@turf/circle": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.1.0.tgz",
+      "integrity": "sha512-1lIUfqAQvCWAuUNC2ip8UYmM5kDltXOidLPW45Ee1OAIKYGBeFNtjwnxc0mQ40tnfTXclTYLDdOOP9LShspT9w==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/length": "^7.1.0",
+        "@turf/line-slice-along": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.1.0.tgz",
+      "integrity": "sha512-JI3dvOsAoCqd4vUJ134FIzgcC42QpC/tBs+b4OJoxWmwDek3REv4qGaZY6wCg9X4hFSlCKFcnhMIQQZ/n720Qg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.1.0.tgz",
+      "integrity": "sha512-pz6irzhiQlJurU7DoXada6k3ei7PzY+VpsE/Wotm0D2KEAnoxqum2WK0rqqrhKPHKn+xpUGsHN9W/6K+qtmaHg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.1.0.tgz",
+      "integrity": "sha512-BdHuEoFAtqvVw3LkjCdivG035nfuwZuxji2ijst+mkmDnlv7uwSBudJqcDGjU6up2r8P1mXChS4im4xjUz+lwg==",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/geojson-rbush": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-segment": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/nearest-point-on-line": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.1.0.tgz",
+      "integrity": "sha512-9rgIIH6ZzC3IiWxDQtKsq+j6eu8fRinMkJeusfI9HqOTm4vO02Ll4F/FigjOMOO/6X3TJ+Pqe3gS99TUaBINkw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.1.0.tgz",
+      "integrity": "sha512-44xcjgMQxTa7tTAZlSD3t1cFjHi5SCfAqjg1ONv45EYKsQSonPaxD7LGzCbU5pR2RJjx3R7QRJx2G88hnGcXjQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/nearest-point-on-line": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.1.0.tgz",
+      "integrity": "sha512-UwfnFORZnu4xdnuRXiQM3ODa8f9Q0FBjQF/XHNsPEI/xxmnwgQj3MZiULbAeHUbtU/7psTC7gEjfE3Lf0tcKQw==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.1.0.tgz",
+      "integrity": "sha512-QqUAmtlrnEu75cpLOmpEuiYU63BeVwpSKOBllBbu5gkP+7H/WBM/9fh7J0VgHNFHzqZCKiu8v4158k+CZr0QAg==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/geojson-rbush": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/line-segment": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/nearest-point-on-line": "^7.1.0",
+        "@turf/square": "^7.1.0",
+        "@turf/truncate": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.1.0.tgz",
+      "integrity": "sha512-n/IWBRbo+l4XDTz4sfQsQm5bU9xex8KrthK397jQasd7a9PiOKGon9Z1t/lddTJhND6ajVyJ3hl+eZMtpQaghQ==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.1.0.tgz",
+      "integrity": "sha512-d+u3IIiRhe17TDfP/+UMn9qRlJYPJpK7sj6WorsssluGi0yIG/Z24uWpcLskWKSI8NNgkIbDrp+GIYkJi2t7SA==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "polygon-clipping": "^0.15.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.1.0.tgz",
+      "integrity": "sha512-uiUU9TwRZOCeiTUn8+7oE6MJUvclfq+n6KQ5VCMTZXiRUJjPu7nDLpBle1t2WSv7/w7O0kSQ4FfKXh0gHnkJOw==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.1.0.tgz",
+      "integrity": "sha512-xsvAr3IRF/C6PlRMoN/ANrRx6c3QFUJgBCIVfI7re+Lkdprrzgw1HZA48ZjP4F91xbhgA1scnRgQdHFi2vO2SA==",
+      "dependencies": {
+        "@turf/distance-weight": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.1.0.tgz",
+      "integrity": "sha512-FAhT8/op3DuvqH0XFhv055JhYq/FC4aaIxEZ4hj8c7W6sYhUHAQgdRZ0tJ1RLe5/h+eXhCTbQ+DFfnfv3klu8g==",
+      "dependencies": {
+        "@turf/area": "^7.1.0",
+        "@turf/bbox": "^7.1.0",
+        "@turf/bbox-polygon": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/nearest-point": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.1.0.tgz",
+      "integrity": "sha512-VyInmhqfVWp+jE7sCK95o46qc4tDjAgzbRfRjr+rTgfFS1Sndyy1PdwyNn6TjBFDxiM6e+mjMEeGPjb1smJlEg==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.1.0.tgz",
+      "integrity": "sha512-aTjAOm7ab0tl5JoxGYRx/J/IbRL1DY1ZCIYQDMEQjK5gOllhclgeBC0wDXDkEZFGaVftjw0W2RtE2I0jX7RG4A==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.1.0.tgz",
+      "integrity": "sha512-rY2F/iY4S6U8H0hIoOI25xMWYEiKywxeTvTvn5GP8KCu+2oemfZROWa7n2+hQDRwO2/uaegrGEpxO7zlFarvzg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/point-to-line-distance": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.1.0.tgz",
+      "integrity": "sha512-hFORBkCd7Q0kNUzLqksT4XglLgTQF9tCjG+dbnZ1VehpZu+w+vlHdoW/mY7XCX3Kj1ObiyzVmXffmVYgwXwF6Q==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.1.0.tgz",
+      "integrity": "sha512-ihuuUcWuCu4Z1+34UYCM5NGsU2DJaB4uE8cS3jDQoUqlc+8ii2ng8kcGEtTwVn0HdPsoKA7bgvSZcisJO0v6Ww==",
+      "dependencies": {
+        "@turf/boolean-within": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.1.0.tgz",
+      "integrity": "sha512-lOO5J9I0diuGbN+r6jViEKRH3qfymsBvv25b7U0MuP8g/YC19ncUXZ86dmKfJx1++Rb485DS9h0nFvPmJpaOdg==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/center": "^7.1.0",
+        "@turf/explode": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/nearest-point": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.1.0.tgz",
+      "integrity": "sha512-Ps9eTOCaiNgxDaSNQux0wAcSLcrI0y0zYFaD9HnVm+yCMRliQXneFti2XXotS+gR7TpgnLRAAzyx4VzJMSN2tw==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/projection": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@turf/rhumb-distance": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.1.0.tgz",
+      "integrity": "sha512-SzqeD9Gcp11rEya+rCVMy6IPuYMrphNEkCiQ39W6ec9hsaqKlruqmtudKhhckMGVLVUUBCQAu5f55yjcDfVW2w==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.1.0.tgz",
+      "integrity": "sha512-mTlmg4XUP5rKgCP/73N91owkAXIc3t1ZKLuwsJGQM1/Op48T3rJmDwVR/WZIMnVlxl5tFbssWCCB3blj4ivx9g==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.1.0.tgz",
+      "integrity": "sha512-ffBgHXtkrpgkNs8E6s9sVLSKG4lPGH3WBk294FNKBt9NS+rbhNCv8yTuOMeP0bOm/WizaCq/SUtVryJpUSoI/g==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/boolean-within": "^7.1.0",
+        "@turf/explode": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/nearest-point": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.1.0.tgz",
+      "integrity": "sha512-FBlfyBWNQZCTVGqlJH7LR2VXmvj8AydxrA8zegqek/5oPGtQDeUgIppKmvmuNClqbglhv59QtCUVaDK4bOuCTA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.1.0.tgz",
+      "integrity": "sha512-FBjxnOzO29MbE7MWnMPHHYtOo93cQopT5pXhkuPyoKgcTUCntR1+iVFpl5YFbMkYup0j5Oexjo/pbY38lVSZGw==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/envelope": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.1.0.tgz",
+      "integrity": "sha512-3wHluMoOvXnTe7dfi0kcluTyLNG5MwGsSsK5OA98vkkLH6a1xvItn8e9GcesuT07oB2km/bgefxYEIvjQG5JCA==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.1.0.tgz",
+      "integrity": "sha512-4O5h9PyWgpqYXja9O+kzr+qk5MUz0IkJqPtt5oWWX5s4jRcLNqiEUf+zi/GDBQkVV8jH3S5klT5CLrF1fxK3hQ==",
+      "dependencies": {
+        "@turf/area": "^7.1.0",
+        "@turf/bbox": "^7.1.0",
+        "@turf/bbox-polygon": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/point-grid": "^7.1.0",
+        "@turf/random": "^7.1.0",
+        "@turf/square-grid": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.1.0.tgz",
+      "integrity": "sha512-22mXv8ejDMUWkz8DSMMqdZb0s7a0ISJzXt6T9cHovfT//vsotzkVH+5PDxJQjvmigKMnpaUgobHmQss23tAwEQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.1.0.tgz",
+      "integrity": "sha512-4d2AuDj4LfMMJxNHbds5yX1oFR3mIVAB5D7mx6pFB0e+YkQW0mE2dUWhDTFGJZM+n45yqbNQ5hg19bmiXv94ug==",
+      "dependencies": {
+        "@turf/boolean-intersects": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.1.0.tgz",
+      "integrity": "sha512-zX0KDZpeiH89m1vYLTEJdDL6mFyoAsCxcG0P94mXO7/JXWf0AaxzA9MkNnA/d2QYX0G4ioCMjZ5cD6nXb8SXzw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.1.0.tgz",
+      "integrity": "sha512-ESZt70eOljHVnQMFKIdiu8LIHuQlpZgzh2nqSfV40BrYjsjI/sBKeK+sp2cBWk88nsSDlriPuMTNh4f50Jqpkw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.1.0.tgz",
+      "integrity": "sha512-WA2TeO3qrv5ZrzNihtTLLYu8X4kd12WEC6JKElm99XhgLao1/4ao2SJUi43l88HqwbrnNiq4TueGQ6tYpXGU7A==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.1.0.tgz",
+      "integrity": "sha512-fR1V+yC4E1tnbdThomosiLcv0PQOwbfLSPM8rSWuxbMcJtffsncWxyJ0+N1F5juuHbcdaYhlduX8ri5I0ZCejw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.1.0.tgz",
+      "integrity": "sha512-9Iq/Ankr4+sgBoh4FpuVVvoW+AA10eej3FS89Zu79SFdCqUIdT7T42Nn3MlSVj4jMyA1oXyT2HIAlNWkwgLw6Q==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.1.0.tgz",
+      "integrity": "sha512-2FI2rg//eXpa/l+WJtFfvHaf1NJ7ie2MoJ+RH5dKANtrfoof1Ed+y9dXSyuhem2tp/Srq2GhrjaSofFN5/g5vA==",
+      "dependencies": {
+        "@turf/circle": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-arc": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.1.0.tgz",
+      "integrity": "sha512-1UmFhS5zHNacLv5rszoFOXq02BGov1oJvjlDatXsSWAd+Z7tqxpDc8D+41edrXy0ZB0Yxsy6WPNagM6hG9PRaA==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/bbox-polygon": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/clean-coords": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/transform-scale": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.1.0.tgz",
+      "integrity": "sha512-JypymaoiSiFzGHwEoUkK0OPW1KQSnH3hEsEW3UIRS+apzltJ4HdFovYjsfqQgGZJZ+NJ9+dv7h8pgGLYuqcBUQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.1.0.tgz",
+      "integrity": "sha512-ANuA+WXZheGTLW6Veq0i+/B2S4KMhEHAixDv9gQEb9e6FTyqTJVwrqP4CHI3OzA3DZ/ytFf+NTKVofetO/BBQg==",
+      "dependencies": {
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.1.0.tgz",
+      "integrity": "sha512-JyhsALULVRlkh8htdTi9aXaXFSUv6wRNbeFbqyGJKKlA5eF+AYmyWdI/BlFGQN27xtbtMPeAuLmj+8jaB2omGw==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/rectangle-grid": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.1.0.tgz",
+      "integrity": "sha512-JqvQFH/witHh+3XgPC1Qk4+3G8w8WQta2NTJjnGinOgFulH+7RD4DcxCT+XXtCHoeq8IvL9VPJRX3ciaW5nSCg==",
+      "dependencies": {
+        "@turf/center-mean": "^7.1.0",
+        "@turf/ellipse": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/points-within-polygon": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.1.0.tgz",
+      "integrity": "sha512-cD8TC++DnNmdI1B/apTf3nj2zRNY6SoLRliB8K76OB+70Kev8tOf4ZVgAqOd0u+Hpdg/T6l7dO7fyJ6UouE7jA==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.1.0.tgz",
+      "integrity": "sha512-E/Z94Mx6kUjvQVbEcSuM9MbEo2dkOczRe4ZzjhFlLgJh1dCkfRgwYLH49mb2CcfG/me1arxoCgmtG+qgm7LrCg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.1.0.tgz",
+      "integrity": "sha512-h8Bdm0IYN6OpKHM8lBRWGxkJnZcxL0KYecf8U6pa6DCEYsEXuEExMTvYSD2OmqIsL5ml8P6RjwgyI+dZeE0O9A==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.1.0.tgz",
+      "integrity": "sha512-Vp7VBZ6DqaPV8mkwSycksBFRLqSj3y16zg+uEPSCsXUjbFtw9DOLcyH2F5vMpnC2bOpS9NOB4hebhJRwBwAPWQ==",
+      "dependencies": {
+        "@turf/centroid": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@turf/rhumb-destination": "^7.1.0",
+        "@turf/rhumb-distance": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.1.0.tgz",
+      "integrity": "sha512-m5fLnh3JqrWSv0sAC8Aieet/fr5IZND8BFaE9LakMidtNaJqOIPOyVmUoklcrGn6eK6MX+66rRPn+5a1pahlLQ==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/center": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@turf/rhumb-destination": "^7.1.0",
+        "@turf/rhumb-distance": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.1.0.tgz",
+      "integrity": "sha512-XA6Oh7VqUDrieY9m9/OF4XpBTd8qlfVGi3ObywojCqtHaHKLK3aXwTBZ276i0QKmZqOQA+2jFa9NhgF/TgBDrw==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/rhumb-destination": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.1.0.tgz",
+      "integrity": "sha512-hrPyRAuX5PKu7txmc/11VPKrlJDR+JGzd+eijupKTspNLR4n2sqZUx8UXqSxZ/1nq06ScTyjIfGQJVzlRS8BTg==",
+      "dependencies": {
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/intersect": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.1.0.tgz",
+      "integrity": "sha512-rrF3AML9PGZw2i5wmt53ESI+Ln9cZyCXgJ7QrEvkT8NbE4OFgmw6p8/1xT8+VEWFSpD4gHz+hmM+5FaFxXvtNg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.1.0.tgz",
+      "integrity": "sha512-7NA6tAjbu9oIvIfpRO5AdPrZbFTlUFU02HVA7sLJM9jFeNIZovW09QuDo23uoS2z5l94SXV1GgKKxN5wo7prCw==",
+      "dependencies": {
+        "@turf/along": "^7.1.0",
+        "@turf/angle": "^7.1.0",
+        "@turf/area": "^7.1.0",
+        "@turf/bbox": "^7.1.0",
+        "@turf/bbox-clip": "^7.1.0",
+        "@turf/bbox-polygon": "^7.1.0",
+        "@turf/bearing": "^7.1.0",
+        "@turf/bezier-spline": "^7.1.0",
+        "@turf/boolean-clockwise": "^7.1.0",
+        "@turf/boolean-concave": "^7.1.0",
+        "@turf/boolean-contains": "^7.1.0",
+        "@turf/boolean-crosses": "^7.1.0",
+        "@turf/boolean-disjoint": "^7.1.0",
+        "@turf/boolean-equal": "^7.1.0",
+        "@turf/boolean-intersects": "^7.1.0",
+        "@turf/boolean-overlap": "^7.1.0",
+        "@turf/boolean-parallel": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/boolean-point-on-line": "^7.1.0",
+        "@turf/boolean-touches": "^7.1.0",
+        "@turf/boolean-valid": "^7.1.0",
+        "@turf/boolean-within": "^7.1.0",
+        "@turf/buffer": "^7.1.0",
+        "@turf/center": "^7.1.0",
+        "@turf/center-mean": "^7.1.0",
+        "@turf/center-median": "^7.1.0",
+        "@turf/center-of-mass": "^7.1.0",
+        "@turf/centroid": "^7.1.0",
+        "@turf/circle": "^7.1.0",
+        "@turf/clean-coords": "^7.1.0",
+        "@turf/clone": "^7.1.0",
+        "@turf/clusters": "^7.1.0",
+        "@turf/clusters-dbscan": "^7.1.0",
+        "@turf/clusters-kmeans": "^7.1.0",
+        "@turf/collect": "^7.1.0",
+        "@turf/combine": "^7.1.0",
+        "@turf/concave": "^7.1.0",
+        "@turf/convex": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/difference": "^7.1.0",
+        "@turf/dissolve": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/distance-weight": "^7.1.0",
+        "@turf/ellipse": "^7.1.0",
+        "@turf/envelope": "^7.1.0",
+        "@turf/explode": "^7.1.0",
+        "@turf/flatten": "^7.1.0",
+        "@turf/flip": "^7.1.0",
+        "@turf/geojson-rbush": "^7.1.0",
+        "@turf/great-circle": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/hex-grid": "^7.1.0",
+        "@turf/interpolate": "^7.1.0",
+        "@turf/intersect": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/isobands": "^7.1.0",
+        "@turf/isolines": "^7.1.0",
+        "@turf/kinks": "^7.1.0",
+        "@turf/length": "^7.1.0",
+        "@turf/line-arc": "^7.1.0",
+        "@turf/line-chunk": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/line-offset": "^7.1.0",
+        "@turf/line-overlap": "^7.1.0",
+        "@turf/line-segment": "^7.1.0",
+        "@turf/line-slice": "^7.1.0",
+        "@turf/line-slice-along": "^7.1.0",
+        "@turf/line-split": "^7.1.0",
+        "@turf/line-to-polygon": "^7.1.0",
+        "@turf/mask": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@turf/midpoint": "^7.1.0",
+        "@turf/moran-index": "^7.1.0",
+        "@turf/nearest-neighbor-analysis": "^7.1.0",
+        "@turf/nearest-point": "^7.1.0",
+        "@turf/nearest-point-on-line": "^7.1.0",
+        "@turf/nearest-point-to-line": "^7.1.0",
+        "@turf/planepoint": "^7.1.0",
+        "@turf/point-grid": "^7.1.0",
+        "@turf/point-on-feature": "^7.1.0",
+        "@turf/point-to-line-distance": "^7.1.0",
+        "@turf/points-within-polygon": "^7.1.0",
+        "@turf/polygon-smooth": "^7.1.0",
+        "@turf/polygon-tangents": "^7.1.0",
+        "@turf/polygon-to-line": "^7.1.0",
+        "@turf/polygonize": "^7.1.0",
+        "@turf/projection": "^7.1.0",
+        "@turf/quadrat-analysis": "^7.1.0",
+        "@turf/random": "^7.1.0",
+        "@turf/rectangle-grid": "^7.1.0",
+        "@turf/rewind": "^7.1.0",
+        "@turf/rhumb-bearing": "^7.1.0",
+        "@turf/rhumb-destination": "^7.1.0",
+        "@turf/rhumb-distance": "^7.1.0",
+        "@turf/sample": "^7.1.0",
+        "@turf/sector": "^7.1.0",
+        "@turf/shortest-path": "^7.1.0",
+        "@turf/simplify": "^7.1.0",
+        "@turf/square": "^7.1.0",
+        "@turf/square-grid": "^7.1.0",
+        "@turf/standard-deviational-ellipse": "^7.1.0",
+        "@turf/tag": "^7.1.0",
+        "@turf/tesselate": "^7.1.0",
+        "@turf/tin": "^7.1.0",
+        "@turf/transform-rotate": "^7.1.0",
+        "@turf/transform-scale": "^7.1.0",
+        "@turf/transform-translate": "^7.1.0",
+        "@turf/triangle-grid": "^7.1.0",
+        "@turf/truncate": "^7.1.0",
+        "@turf/union": "^7.1.0",
+        "@turf/unkink-polygon": "^7.1.0",
+        "@turf/voronoi": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.1.0.tgz",
+      "integrity": "sha512-7VI8jONdBg9qmbfNlLQycPr93l5aU9HGMgWI9M6pb4ERuU2+p8KgffCgs2NyMtP2HxPrKSybzj31g7bnbEKofQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "polygon-clipping": "^0.15.3",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.1.0.tgz",
+      "integrity": "sha512-pqkirni2aLpRA1ELFIuJz+mkjYyJQX8Ar6BflSu1b0ajY/CTrcDxbIv1x8UfvbybLzdJc4Gxzg5mo4cEtSwtaQ==",
+      "dependencies": {
+        "@turf/area": "^7.1.0",
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.1.0.tgz",
+      "integrity": "sha512-xUvzPDG6GaqEekgxd+pjeMKJXOYJ3eFIqUHbTe/ISKzzv3f2cFGiR2VH7ZGXri8d4ozzCQbUQ27ilHPPLf5+xw==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2229,6 +4300,11 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true
     },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2238,8 +4314,7 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-      "dev": true
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2348,11 +4423,15 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/rbush": {
       "version": "3.0.4",
@@ -2364,7 +4443,6 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2375,6 +4453,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3125,6 +5211,35 @@
         "deep-equal": "^2.0.5"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3240,7 +5355,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3555,6 +5669,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -3570,6 +5689,30 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/concaveman/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/concaveman/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -3806,6 +5949,24 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3876,11 +6037,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
       "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4050,6 +6219,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -4146,7 +6324,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4388,7 +6565,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5361,6 +7537,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5513,7 +7694,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5552,6 +7732,35 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz",
+      "integrity": "sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dependencies": {
+        "quickselect": "^1.0.1"
       }
     },
     "node_modules/geotiff": {
@@ -5771,7 +7980,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5841,6 +8049,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -5936,7 +8153,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5949,6 +8165,19 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hook-std": {
       "version": "3.0.0",
@@ -6075,7 +8304,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -6236,8 +8464,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-async-function": {
       "version": "2.0.0",
@@ -6319,7 +8546,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -6956,7 +9182,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6979,8 +9204,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7047,6 +9271,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7132,8 +9364,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -7279,6 +9510,11 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/marchingsquares": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/marchingsquares/-/marchingsquares-1.3.3.tgz",
+      "integrity": "sha512-gz6nNQoVK7Lkh2pZulrT4qd4347S/toG9RXH2pyzhLgkL5mLkBoqgv4EvAGXcV0ikDW72n/OQb3Xe8bGagQZCg=="
+    },
     "node_modules/marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -7349,6 +9585,11 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/meow": {
       "version": "12.1.1",
@@ -7472,13 +9713,12 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.1.tgz",
-      "integrity": "sha512-HXcoQPzYTwEmVk+BGIcRa0vLabBT+J20SSSeYh/QfajaK5ceA6dlD4ZZjfz2dqGEq4vRNCPLP6eXsB94KllPFg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.4.tgz",
+      "integrity": "sha512-iuM0qGs4YmgYCLH+xqb07w2e/e4fYmsx3+WHVlIOUA34TW1sw+wRpNmOlXnLDkw/T7233Jnm6t+aNf4v2E3e2Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7486,11 +9726,12 @@
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
         "@inquirer/confirm": "^3.0.0",
-        "@mswjs/interceptors": "^0.29.0",
+        "@mswjs/interceptors": "^0.35.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
         "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.2",
@@ -7509,13 +9750,9 @@
         "url": "https://github.com/sponsors/mswjs"
       },
       "peerDependencies": {
-        "graphql": ">= 16.8.x",
-        "typescript": ">= 4.7.x"
+        "typescript": ">= 4.8.x"
       },
       "peerDependenciesMeta": {
-        "graphql": {
-          "optional": true
-        },
         "typescript": {
           "optional": true
         }
@@ -10515,7 +12752,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -10533,7 +12769,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10589,8 +12824,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.2",
@@ -10602,7 +12836,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10637,8 +12870,7 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10731,6 +12963,30 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.1.0.tgz",
+      "integrity": "sha512-3hTIM2j/v9Lio+wOyur3kckD4NxruZhpowUbEgmyikW+a2Kppjtu1eN+AhnMQtoHW46zld88JiYWv6fxpsDrTQ=="
+    },
+    "node_modules/polygon-clipping": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
+      "integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2",
+        "splaytree": "^3.1.0"
+      }
+    },
+    "node_modules/polygon-clipping/node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -11079,6 +13335,21 @@
         "react-dom": ">= 16.3.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.53.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+      "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
@@ -11144,6 +13415,26 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-select": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-tooltip": {
       "version": "5.28.0",
       "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
@@ -11155,6 +13446,21 @@
       "peerDependencies": {
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-universal-interface": {
@@ -11404,7 +13710,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -11421,7 +13726,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11469,6 +13773,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="
     },
     "node_modules/rollup": {
       "version": "4.21.2",
@@ -11934,6 +14243,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12014,6 +14328,11 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true
+    },
+    "node_modules/splaytree": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
+      "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A=="
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -12687,7 +15006,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12700,6 +15018,14 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -12866,6 +15192,11 @@
         "node": "^18.0.0 || >=20.0.0"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
@@ -12888,7 +15219,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12909,6 +15239,30 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
@@ -13275,6 +15629,19 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {
@@ -13722,6 +16089,14 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -13771,6 +16146,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zstddec": {

--- a/package.json
+++ b/package.json
@@ -24,17 +24,23 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
+    "@turf/turf": "^7.1.0",
     "axios": "^1.7.4",
+    "date-fns": "^3.6.0",
     "leaflet": "^1.9.4",
     "optionator": "^0.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-draggable": "^4.4.6",
+    "react-hook-form": "^7.53.0",
     "react-icons": "^5.2.1",
     "react-responsive-pagination": "^2.6.0",
     "react-router-dom": "^6.21.1",
+    "react-select": "^5.8.0",
     "react-tooltip": "^5.28.0",
-    "react-use": "^17.5.1"
+    "react-use": "^17.5.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@axe-core/react": "^4.9.1",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.1'
+const PACKAGE_VERSION = '2.4.4'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 
 import { TbLayoutSidebarRightCollapseFilled } from 'react-icons/tb';
 
 import { Axe } from '@/components/Axe';
 import FilterSidebar from '@/components/FilterSidebar';
 import { useApp } from '@/hooks/useApp';
-import DataCatalogue from '@/pages/DataCatalogue';
-import MapViewer from '@/pages/MapViewer';
+
+const DataCatalogue = lazy(() => import('@/pages/DataCatalogue'));
+const MapViewer = lazy(() => import('@/pages/MapViewer'));
 
 const App: React.FC = () => {
   const { state: AppState, actions: AppActions } = useApp();
@@ -36,8 +37,16 @@ const App: React.FC = () => {
       <div
         className={`main-content-container ${!filterSidebarOpen ? 'main-content-container-full' : ''}`}
       >
-        {activeContent === 'dataCatalogue' && <DataCatalogue />}
-        {activeContent === 'map' && <MapViewer />}
+        {activeContent === 'dataCatalogue' && (
+          <Suspense>
+            <DataCatalogue />
+          </Suspense>
+        )}
+        {activeContent === 'map' && (
+          <Suspense>
+            <MapViewer />
+          </Suspense>
+        )}
       </div>
     </main>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,12 @@
-import React, { Suspense, lazy } from 'react';
+import React from 'react';
 
 import { TbLayoutSidebarRightCollapseFilled } from 'react-icons/tb';
 
 import { Axe } from '@/components/Axe';
 import FilterSidebar from '@/components/FilterSidebar';
 import { useApp } from '@/hooks/useApp';
-
-const DataCatalogue = lazy(() => import('@/pages/DataCatalogue'));
-const MapViewer = lazy(() => import('@/pages/MapViewer'));
+import DataCatalogue from '@/pages/DataCatalogue';
+import MapViewer from '@/pages/MapViewer';
 
 const App: React.FC = () => {
   const { state: AppState, actions: AppActions } = useApp();
@@ -37,16 +36,8 @@ const App: React.FC = () => {
       <div
         className={`main-content-container ${!filterSidebarOpen ? 'main-content-container-full' : ''}`}
       >
-        {activeContent === 'dataCatalogue' && (
-          <Suspense>
-            <DataCatalogue />
-          </Suspense>
-        )}
-        {activeContent === 'map' && (
-          <Suspense>
-            <MapViewer />
-          </Suspense>
-        )}
+        {activeContent === 'dataCatalogue' && <DataCatalogue />}
+        {activeContent === 'map' && <MapViewer />}
       </div>
     </main>
   );

--- a/src/components/accordion/Accordion.scss
+++ b/src/components/accordion/Accordion.scss
@@ -1,0 +1,25 @@
+@import '@/styles/main';
+
+.accordion {
+  list-style-type: none;
+
+  .accordion-item {
+    .title {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      background-color: $primary-colour;
+      padding: 0.5rem 1rem;
+      font-weight: bolder;
+      color: #fff;
+    }
+
+    .content {
+      padding: 1rem;
+    }
+
+    .active {
+      background-color: $secondary-colour;
+    }
+  }
+}

--- a/src/components/accordion/Accordion.scss
+++ b/src/components/accordion/Accordion.scss
@@ -2,6 +2,7 @@
 
 .accordion {
   list-style-type: none;
+  padding: unset;
 
   .accordion-item {
     .title {

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+type AccordionItemProps = {
+  children: ReactNode;
+};
+
+export const Accordion = ({ children }: AccordionItemProps) => {
+  return <ul className="accordion">{children}</ul>;
+};

--- a/src/components/accordion/AccordionItem.test.tsx
+++ b/src/components/accordion/AccordionItem.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, userEvent } from '@/utils/renderers';
+
+import { AccordionItem } from './AccordionItem';
+
+describe('AccordionItem Component', () => {
+  const mockOnClick = vi.fn();
+
+  it('should render the accordion item with label and plus icon when inactive', () => {
+    render(
+      <AccordionItem isActive={false} label="Test Label" onClick={mockOnClick}>
+        <p>Test Content</p>
+      </AccordionItem>,
+    );
+
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /test label/i });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toHaveClass('active');
+
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+
+    expect(button?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should render the accordion item with minus icon and content when active', () => {
+    render(
+      <AccordionItem isActive={true} label="Test Label" onClick={mockOnClick}>
+        <p>Test Content</p>
+      </AccordionItem>,
+    );
+
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /test label/i });
+    expect(button).toHaveClass('active');
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    expect(button?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should trigger onClick when clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AccordionItem isActive={false} label="Test Label" onClick={mockOnClick}>
+        <p>Test Content</p>
+      </AccordionItem>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /test label/i }));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/accordion/AccordionItem.tsx
+++ b/src/components/accordion/AccordionItem.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+import { FaMinus, FaPlus } from 'react-icons/fa';
+
+import './Accordion.scss';
+
+type AccordionItemProps = {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  children: ReactNode;
+};
+
+export const AccordionItem = ({ label, onClick, isActive, children }: AccordionItemProps) => {
+  return (
+    <li className={`accordion-item`}>
+      <button className={`title ${isActive ? 'active' : ''}`} onClick={onClick}>
+        {label}
+        <span className="control">{isActive ? <FaMinus /> : <FaPlus />}</span>
+      </button>
+
+      {isActive ? <div className="content">{children}</div> : null}
+    </li>
+  );
+};

--- a/src/components/form/FormField.scss
+++ b/src/components/form/FormField.scss
@@ -1,0 +1,7 @@
+@import './form';
+
+.form-field {
+  border: 1px solid #000;
+  border-radius: 0.3rem;
+  padding: 0.3rem;
+}

--- a/src/components/form/FormField.test.tsx
+++ b/src/components/form/FormField.test.tsx
@@ -1,0 +1,126 @@
+import { SubmitHandler, UseFormRegister, useForm } from 'react-hook-form';
+
+import { render, screen, userEvent, waitFor } from '@/utils/renderers';
+
+import { FormField } from './FormField';
+
+interface FormValues {
+  name: string;
+  startDate: string;
+}
+
+// Mock form setup
+const MockForm = ({ onSubmit }: { onSubmit: SubmitHandler<FormValues> }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormField<FormValues>
+        error={errors.name}
+        label="Name"
+        name="name" // Explicitly type this as 'name' from FormValues
+        placeholder="Enter your name"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        label="Start Date"
+        min="2024-09-01"
+        name="startDate" // Explicitly type this as 'startDate' from FormValues
+        register={register}
+        type="date"
+      />
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+describe('FormField Component', () => {
+  const mockRegister: UseFormRegister<FormValues> = () => ({
+    // @ts-expect-error: Typescript error I cannot seem to resolve
+    name: 'name',
+    onChange: vi.fn(),
+    onBlur: vi.fn(),
+    ref: vi.fn(),
+  });
+
+  it('should render inputs with label', () => {
+    render(<MockForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('textbox', { name: /name/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('should apply error styles when error is present', () => {
+    const errorMsg = 'This field is required';
+
+    render(
+      <FormField<FormValues>
+        error={{ message: errorMsg, type: 'required' }}
+        label="Name"
+        name="name"
+        register={mockRegister}
+        type="text"
+      />,
+    );
+
+    expect(screen.getByRole('textbox', { name: /name/i })).toHaveStyle({ borderColor: '#ff0000' });
+    expect(screen.getByRole('paragraph', { name: /field-error/i })).toBeInTheDocument();
+  });
+
+  it('should handle disabled state', () => {
+    render(
+      <FormField<FormValues>
+        disabled
+        label="Name"
+        name="name"
+        register={mockRegister}
+        type="text"
+      />,
+    );
+
+    expect(screen.getByRole('textbox', { name: /name/i })).toBeDisabled();
+  });
+
+  it('should apply min attribute for date input', () => {
+    render(
+      <FormField<FormValues>
+        label="Start Date"
+        min="2024-09-01"
+        name="startDate"
+        register={mockRegister}
+        type="date"
+      />,
+    );
+
+    expect(screen.getByLabelText('Start Date')).toHaveAttribute('min', '2024-09-01');
+  });
+
+  it('should submit form with user input', async () => {
+    const onSubmit = vi.fn();
+
+    render(<MockForm onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /name/i }), 'John Doe');
+    await userEvent.type(screen.getByLabelText('Start Date'), '2024-09-02');
+
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          name: 'John Doe',
+          startDate: '2024-09-02',
+        },
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -1,0 +1,46 @@
+import { FieldError, FieldValues, Path, UseFormRegister } from 'react-hook-form';
+
+import './FormField.scss';
+
+type FormFieldProps<T extends FieldValues> = {
+  label: string;
+  name: Path<T>;
+  type: string;
+  placeholder?: string;
+  register: UseFormRegister<T>;
+  error?: FieldError;
+  disabled?: boolean;
+  min?: string;
+};
+
+export const FormField = <T extends FieldValues>({
+  label,
+  name,
+  type,
+  placeholder,
+  register,
+  error,
+  disabled = false,
+  min,
+}: FormFieldProps<T>) => (
+  <>
+    <label htmlFor={name}>{label}</label>
+    <input
+      id={name}
+      placeholder={placeholder ?? ''}
+      type={type}
+      {...register(name)}
+      className="form-field"
+      disabled={disabled}
+      style={{
+        borderColor: error ? '#ff0000' : '#000',
+      }}
+      {...(type === 'date' && min ? { min } : {})}
+    />
+    {error && (
+      <p aria-label="field-error" className="field-error">
+        {error.message}
+      </p>
+    )}
+  </>
+);

--- a/src/components/form/RangeSliderField.scss
+++ b/src/components/form/RangeSliderField.scss
@@ -1,0 +1,10 @@
+.range-slider {
+  display: flex;
+  flex-direction: column;
+
+  datalist {
+    display: flex;
+    padding: 0 0.75rem;
+    justify-content: space-between;
+  }
+}

--- a/src/components/form/RangeSliderField.test.tsx
+++ b/src/components/form/RangeSliderField.test.tsx
@@ -1,0 +1,60 @@
+import { UseFormRegisterReturn } from 'react-hook-form';
+
+import { render, screen, userEvent } from '@/utils/renderers';
+
+import { RangeSliderField } from './RangeSliderField';
+
+describe('RangeSliderField Component', () => {
+  const mockRegister = vi.fn().mockReturnValue({} as UseFormRegisterReturn);
+
+  it('should render the range slider with correct label and attributes', () => {
+    render(
+      <RangeSliderField
+        label="Select a value"
+        max={100}
+        min={0}
+        name="range"
+        register={mockRegister}
+      />,
+    );
+
+    const slider = screen.getByRole('slider', { name: /select a value/i });
+
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('min', '0');
+    expect(slider).toHaveAttribute('max', '100');
+  });
+
+  it('should allow the user to interact with the slider', async () => {
+    const user = userEvent.setup();
+    render(
+      <RangeSliderField
+        label="Select a value"
+        max={100}
+        min={0}
+        name="range"
+        register={mockRegister}
+      />,
+    );
+
+    const slider = screen.getByRole('slider', { name: /select a value/i });
+    await user.type(slider, '50');
+
+    expect(slider).toHaveValue('50');
+  });
+
+  it('should disable the slider when the disabled prop is true', () => {
+    render(
+      <RangeSliderField
+        disabled
+        label="Select a value"
+        max={100}
+        min={0}
+        name="range"
+        register={mockRegister}
+      />,
+    );
+
+    expect(screen.getByRole('slider', { name: /select a value/i })).toBeDisabled();
+  });
+});

--- a/src/components/form/RangeSliderField.tsx
+++ b/src/components/form/RangeSliderField.tsx
@@ -1,0 +1,46 @@
+import { Path, UseFormRegister } from 'react-hook-form';
+
+import './RangeSliderField.scss';
+
+type RangeSliderFieldProps<TFormValues> = {
+  label: string;
+  name: Path<TFormValues>;
+  register: UseFormRegister<TFormValues>;
+  min: number;
+  max: number;
+  disabled?: boolean;
+};
+
+export const RangeSliderField = <TFormValues extends Record<string, unknown>>({
+  label,
+  name,
+  register,
+  min,
+  max,
+  disabled = false,
+}: RangeSliderFieldProps<TFormValues>) => {
+  return (
+    <>
+      <label htmlFor={name}>{label}</label>
+      <div className="range-slider">
+        <input
+          disabled={disabled}
+          id={name}
+          type="range"
+          {...register(name)}
+          className="form-field"
+          list="values"
+          max={max}
+          min={min}
+        />
+        <datalist id="values">
+          <option label="0" value="0"></option>
+          <option label="25" value="25"></option>
+          <option label="50" value="50"></option>
+          <option label="75" value="75"></option>
+          <option label="100" value="100"></option>
+        </datalist>
+      </div>
+    </>
+  );
+};

--- a/src/components/form/SelectField.scss
+++ b/src/components/form/SelectField.scss
@@ -1,0 +1,1 @@
+@import './form';

--- a/src/components/form/SelectField.test.tsx
+++ b/src/components/form/SelectField.test.tsx
@@ -1,0 +1,53 @@
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { render, screen, userEvent } from '@/utils/renderers';
+
+import { SelectField } from './SelectField';
+
+interface FormValues {
+  select: string;
+}
+
+// Mock form setup
+const MockForm = ({ onSubmit }: { onSubmit: SubmitHandler<FormValues> }) => {
+  const { control, handleSubmit } = useForm<FormValues>();
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <SelectField
+        control={control}
+        label="Select an option"
+        name="select"
+        options={[
+          { value: 'option1', label: 'Option 1' },
+          { value: 'option2', label: 'Option 2' },
+        ]}
+      />
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+describe('SelectField Component', () => {
+  it('should render with label and options', () => {
+    render(<MockForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('should select an option', async () => {
+    render(<MockForm onSubmit={vi.fn()} />);
+
+    const user = userEvent.setup();
+    const select = screen.getByRole('combobox');
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+
+    await user.click(select);
+    await user.click(screen.getByRole('option', { name: /option 1/i }));
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+  });
+});

--- a/src/components/form/SelectField.tsx
+++ b/src/components/form/SelectField.tsx
@@ -1,0 +1,49 @@
+import { Control, Controller, FieldValues, Path } from 'react-hook-form';
+import Select, { GroupBase, Props as SelectProps } from 'react-select';
+
+type OptionType = {
+  value: string;
+  label: string;
+};
+
+type SelectFieldProps<T extends FieldValues> = {
+  label: string;
+  name: Path<T>;
+  control: Control<T>;
+  options: OptionType[];
+  placeholder?: string;
+  isSearchable?: boolean;
+} & Omit<SelectProps<OptionType, boolean, GroupBase<OptionType>>, 'options'>;
+
+export const SelectField = <T extends FieldValues>({
+  label,
+  name,
+  control,
+  options,
+  isSearchable = true,
+  ...rest
+}: SelectFieldProps<T>) => {
+  return (
+    <>
+      <label htmlFor={name}>{label}</label>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field, fieldState }) => (
+          <>
+            <Select
+              id={name}
+              name={name}
+              {...field}
+              isSearchable={isSearchable}
+              options={options}
+              {...rest}
+            />
+
+            {fieldState.error && <p className="field-error">{fieldState.error.message}</p>}
+          </>
+        )}
+      />
+    </>
+  );
+};

--- a/src/components/form/SubmitButton.scss
+++ b/src/components/form/SubmitButton.scss
@@ -1,0 +1,8 @@
+.submit-button {
+  border: 1px solid #000;
+  box-shadow: 5px 5px 5px rgb(0 0 0 / 60%);
+  border-radius: 0.3rem;
+  padding: 0.3rem;
+  color: #fff;
+  font-weight: bolder;
+}

--- a/src/components/form/SubmitButton.tsx
+++ b/src/components/form/SubmitButton.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+import './SubmitButton.scss';
+
+type SubmitButtonProps = {
+  children: string | ReactNode;
+};
+
+export const SubmitButton = ({ children }: SubmitButtonProps) => {
+  return (
+    <button className="submit-button" type="submit">
+      {children}
+    </button>
+  );
+};

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,0 +1,3 @@
+.field-error {
+  color: #f00;
+}

--- a/src/context/FilterContext/index.tsx
+++ b/src/context/FilterContext/index.tsx
@@ -26,7 +26,6 @@ const initialState: FilterState = {
 };
 
 const reducer = (state: FilterState, action: FilterAction): FilterState => {
-  console.log('ACTION PAYLOAD: ', action);
   switch (action.type) {
     case 'SET_FILTER_OPTIONS':
       return { ...state, filterOptions: action.payload };

--- a/src/context/FilterContext/index.tsx
+++ b/src/context/FilterContext/index.tsx
@@ -26,6 +26,7 @@ const initialState: FilterState = {
 };
 
 const reducer = (state: FilterState, action: FilterAction): FilterState => {
+  console.log('ACTION PAYLOAD: ', action);
   switch (action.type) {
     case 'SET_FILTER_OPTIONS':
       return { ...state, filterOptions: action.payload };

--- a/src/context/ToolboxContext/index.tsx
+++ b/src/context/ToolboxContext/index.tsx
@@ -5,7 +5,7 @@ import { FeatureCollection } from 'geojson';
 
 import { useFilters } from '@/hooks/useFilters';
 import { getStacItems } from '@/services/stac';
-import { Collection } from '@/typings/stac';
+import { Collection, Feature as StacFeature } from '@/typings/stac';
 
 import { ToolboxAction, ToolboxContextType, ToolboxProviderProps, ToolboxState } from './types';
 
@@ -16,6 +16,7 @@ const initialState: ToolboxState = {
     type: 'FeatureCollection',
     features: [],
   },
+  selectedCollectionItem: null,
 };
 
 const reducer = (state: ToolboxState, action: ToolboxAction): ToolboxState => {
@@ -26,6 +27,8 @@ const reducer = (state: ToolboxState, action: ToolboxAction): ToolboxState => {
       return { ...state, selectedCollection: action.payload };
     case 'SET_SELECTED_COLLECTION_ITEMS':
       return { ...state, selectedCollectionItems: action.payload };
+    case 'SET_SELECTED_COLLECTION_ITEM':
+      return { ...state, selectedCollectionItem: action.payload };
   }
 };
 
@@ -85,6 +88,12 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
         dispatch({
           type: 'SET_SELECTED_COLLECTION_ITEMS',
           payload: selectedCollectionItems,
+        });
+      },
+      setSelectedCollectionItem: (selectedCollectionItem: StacFeature) => {
+        dispatch({
+          type: 'SET_SELECTED_COLLECTION_ITEM',
+          payload: selectedCollectionItem,
         });
       },
     },

--- a/src/context/ToolboxContext/types.ts
+++ b/src/context/ToolboxContext/types.ts
@@ -3,18 +3,20 @@ import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import { FeatureCollection } from 'geojson';
 
-import { Collection } from '@/typings/stac';
+import { Collection, Feature as StacFeature } from '@/typings/stac';
 
 export interface ToolboxState {
   activePage: string;
   selectedCollection: Collection | null;
   selectedCollectionItems: FeatureCollection;
+  selectedCollectionItem: StacFeature;
 }
 
 export type ToolboxAction =
   | { type: 'SET_ACTIVE_PAGE'; payload: string }
   | { type: 'SET_SELECTED_COLLECTION'; payload: Collection }
-  | { type: 'SET_SELECTED_COLLECTION_ITEMS'; payload: FeatureCollection };
+  | { type: 'SET_SELECTED_COLLECTION_ITEMS'; payload: FeatureCollection }
+  | { type: 'SET_SELECTED_COLLECTION_ITEM'; payload: StacFeature };
 
 export interface ToolboxContextType {
   state: ToolboxState;
@@ -22,6 +24,7 @@ export interface ToolboxContextType {
     setActivePage: (activePage: string) => void;
     setSelectedCollection: (selectedCollection: Collection) => void;
     setSelectedCollectionItems: (selectedCollectionItems: FeatureCollection) => void;
+    setSelectedCollectionItem: (selectedCollectionItem: StacFeature) => void;
   };
 }
 

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
@@ -3,3 +3,10 @@
   overflow-y: auto;
   height: calc(100% - 50px);
 }
+
+.no-items {
+  display: flex;
+  justify-content: center;
+  padding-top: 2rem;
+  color: #f00;
+}

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseForm.test.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseForm.test.tsx
@@ -1,0 +1,83 @@
+import { Feature as StacFeature } from '@/typings/stac';
+import { render, screen, userEvent } from '@/utils/renderers';
+
+import { PurchaseForm } from './PurchaseForm';
+
+describe('PurchaseForm Component', () => {
+  const mockSelectedItem: StacFeature = {
+    id: 'test id',
+    type: 'Feature',
+    bbox: [10, 20, 30, 40],
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [10, 20],
+          [30, 20],
+          [30, 40],
+          [10, 40],
+          [10, 20],
+        ],
+      ],
+    },
+    properties: {
+      datetime: 'test datetime',
+    },
+    links: [],
+  };
+
+  it('should render the form fields correctly', () => {
+    render(<PurchaseForm selectedItem={mockSelectedItem} />);
+
+    expect(screen.getByRole('textbox', { name: /ordername:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /products:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /collection id:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /order size:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /api key:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /contract:/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /licence:/i })).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /create order/i })).toBeInTheDocument();
+  });
+
+  it('should show validation errors for empty required fields', async () => {
+    const user = userEvent.setup();
+    render(<PurchaseForm selectedItem={mockSelectedItem} />);
+
+    await user.click(screen.getByRole('button', { name: /create order/i }));
+
+    const errorMessages = screen.getAllByRole('paragraph', { name: 'field-error' });
+    expect(errorMessages).toHaveLength(6);
+    errorMessages.forEach((error) =>
+      expect(error).toHaveTextContent('Must be at least 3 characters'),
+    );
+  });
+
+  it('should submit the form with valid data', async () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    render(<PurchaseForm selectedItem={mockSelectedItem} />);
+
+    await user.type(screen.getByRole('textbox', { name: /ordername:/i }), 'Test Order');
+    await user.type(screen.getByRole('textbox', { name: /products:/i }), 'Test Product');
+    await user.type(screen.getByRole('textbox', { name: /collection id:/i }), 'Test Collection');
+    await user.type(screen.getByRole('textbox', { name: /api key:/i }), 'Test API Key');
+    await user.type(screen.getByRole('textbox', { name: /contract:/i }), 'Test Contract');
+    await user.type(screen.getByRole('textbox', { name: /licence:/i }), 'Test Licence');
+
+    await user.click(screen.getByRole('button', { name: /create order/i }));
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('SUBMIT FORM DATA: ', {
+      name: 'Test Order',
+      products: 'Test Product',
+      collectionId: 'Test Collection',
+      aoi: '4261422.9 km2', // Example area calculation
+      apiKey: 'Test API Key',
+      contract: 'Test Contract',
+      licence: 'Test Licence',
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+});

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseForm.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseForm.tsx
@@ -1,0 +1,127 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { area } from '@turf/area';
+import { bboxPolygon } from '@turf/bbox-polygon';
+import { convertArea } from '@turf/helpers';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { ZodType, z } from 'zod';
+
+import { FormField } from '@/components/form/FormField';
+import { SubmitButton } from '@/components/form/SubmitButton';
+import { Feature as StacFeature } from '@/typings/stac';
+
+type FormValues = {
+  name: string;
+  products: string;
+  collectionId: string;
+  aoi: string;
+  apiKey: string;
+  contract: string;
+  licence: string;
+};
+
+const PurchaseFormSchema = z.object({
+  name: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  products: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  collectionId: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  aoi: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  apiKey: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  contract: z.string().min(3, { message: 'Must be at least 3 characters' }),
+  licence: z.string().min(3, { message: 'Must be at least 3 characters' }),
+}) as ZodType<FormValues>;
+
+type PurchaseFormProps = {
+  selectedItem: StacFeature;
+};
+
+const defaultValues: FormValues = {
+  name: '',
+  products: '',
+  collectionId: '',
+  aoi: '',
+  apiKey: '',
+  contract: '',
+  licence: '',
+};
+
+export const PurchaseForm = ({ selectedItem }: PurchaseFormProps) => {
+  const itemBboxPolygon = bboxPolygon(selectedItem.bbox);
+  const aoiInMetres = area(itemBboxPolygon);
+  const aoiInKilometers = convertArea(aoiInMetres);
+  const displayArea = Math.round(aoiInKilometers * 10) / 10;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    mode: 'onBlur',
+    resolver: zodResolver(PurchaseFormSchema),
+    defaultValues: { ...defaultValues, aoi: `${displayArea} km2` },
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => console.log('SUBMIT FORM DATA: ', data);
+
+  return (
+    <form className="form" onSubmit={handleSubmit(onSubmit)}>
+      <FormField<FormValues>
+        error={errors.name}
+        label="OrderName:"
+        name="name"
+        placeholder="Enter an Order ID"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        error={errors.products}
+        label="Products:"
+        name="products"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        error={errors.collectionId}
+        label="Collection ID:"
+        name="collectionId"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        disabled
+        error={errors.aoi}
+        label="Order Size:"
+        name="aoi"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        error={errors.apiKey}
+        label="API Key:"
+        name="apiKey"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        error={errors.contract}
+        label="Contract:"
+        name="contract"
+        register={register}
+        type="text"
+      />
+
+      <FormField<FormValues>
+        error={errors.licence}
+        label="Licence:"
+        name="licence"
+        register={register}
+        type="text"
+      />
+
+      <SubmitButton>Create Order</SubmitButton>
+    </form>
+  );
+};

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseFormPanel.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseFormPanel.scss
@@ -1,0 +1,68 @@
+/* stylelint-disable-next-line no-empty-source */
+.button-link {
+  background: none !important;
+  border: none;
+  padding: 0 !important;
+
+  /* optional */
+  font-family: arial, sans-serif;
+
+  /* input has OS specific font-family */
+  color: #069;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.form {
+  // display: flex;
+  // flex-direction: column;
+  // gap: 15px;
+
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-gap: 15px;
+  padding: 1rem;
+
+  label {
+    grid-column: 1/2;
+  }
+
+  input,
+  button {
+    grid-column: 2/3;
+  }
+
+  // .field-error {
+  //   color: #f00;
+  // }
+
+  button {
+    background-color: #008000;
+  }
+}
+
+// .form {
+//   display: flex;
+//   flex-direction: column;
+// }
+
+// .form-field {
+//   display: flex;
+//   flex-direction: column;
+//   padding: 0.5rem;
+// }
+
+// .form-input {
+//   display: flex;
+//   gap: 2rem;
+// }
+
+// .button-wrapper {
+//   align-self: flex-end;
+//   padding: 2rem 1rem 0 0;
+
+//   button {
+//     padding: 0.5rem;
+//     background-color: #069;
+//   }
+// }

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseFormPanel.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/PurchaseFormPanel.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+import { Accordion } from '@/components/accordion/Accordion';
+import { AccordionItem } from '@/components/accordion/AccordionItem';
+import { useToolbox } from '@/hooks/useToolbox';
+
+import { PurchaseForm } from './PurchaseForm';
+import { QueryForm } from './QueryForm';
+
+import './PurchaseFormPanel.scss';
+
+export const PurchaseFormPanel = () => {
+  const {
+    state: { selectedCollectionItem },
+    actions: { setActivePage },
+  } = useToolbox();
+
+  const [selectedItem, setSelectedItem] = useState(null);
+
+  return (
+    <div>
+      <div className="toolbox__header">
+        <button
+          className="button-link"
+          onClick={() => {
+            setActivePage('items');
+          }}
+        >
+          <span>&lt; Return to Items</span>
+        </button>
+      </div>
+
+      <Accordion>
+        <AccordionItem
+          isActive={selectedItem === 'Query type'}
+          label="Query type"
+          onClick={() => {
+            setSelectedItem((prev) => (prev === 'Query type' ? null : 'Query type'));
+          }}
+        >
+          <QueryForm />
+        </AccordionItem>
+
+        <AccordionItem
+          isActive={selectedItem === 'Create Order'}
+          label="Create Order"
+          onClick={() => {
+            setSelectedItem((prev) => (prev === 'Create Order' ? null : 'Create Order'));
+          }}
+        >
+          <PurchaseForm selectedItem={selectedCollectionItem} />
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/QueryForm.test.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/QueryForm.test.tsx
@@ -1,0 +1,112 @@
+import { addDays, format } from 'date-fns';
+
+import { render, screen, userEvent } from '@/utils/renderers';
+
+import { QueryForm } from './QueryForm';
+
+describe('QueryForm Component', () => {
+  it('should render the form fields correctly', () => {
+    render(<QueryForm />);
+
+    // Check if all form fields and submit button are rendered
+    expect(screen.getByLabelText('From:')).toBeInTheDocument();
+    expect(screen.getByLabelText('To:')).toBeInTheDocument();
+    expect(screen.getByText('Data source:')).toBeInTheDocument();
+    expect(screen.getByText('Item type:')).toBeInTheDocument();
+    expect(screen.getByText('Product Bundle:')).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Cloud Cover:' })).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+
+  it('should validate date format and shows error for incorrect date', async () => {
+    const user = userEvent.setup();
+    render(<QueryForm />);
+
+    // Enter invalid dates
+    await user.type(screen.getByLabelText('From:'), '2021-02-30'); // Invalid date
+    await user.type(screen.getByLabelText('To:'), '2021-02-25'); // Valid date
+
+    // Try submitting the form
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    // Expect validation errors for invalid date
+    expect(screen.getByRole('paragraph', { name: /field-error/i })).toBeInTheDocument();
+    expect(screen.getByText('Must be of format YYYY-MM-DD')).toBeInTheDocument();
+  });
+
+  it('should validate that "To" date cannot be earlier than "From" date', async () => {
+    const user = userEvent.setup();
+    render(<QueryForm />);
+
+    // Enter valid but conflicting dates e.g. from tomorrow, to today.
+    const today = new Date();
+    const tomorrow = addDays(today, 1);
+    await user.type(screen.getByLabelText('From:'), format(tomorrow, 'yyyy-MM-dd'));
+    await user.type(screen.getByLabelText('To:'), format(today, 'yyyy-MM-dd'));
+
+    // Try submitting the form
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    // Expect validation error about date mismatch
+    expect(screen.queryByText('To date cannot be earlier than from date.')).toBeInTheDocument();
+  });
+
+  it('should submit the form with valid data', async () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    render(<QueryForm />);
+
+    // Enter valid data
+    const today = new Date();
+    const tomorrow = addDays(today, 1);
+    await user.type(screen.getByLabelText('From:'), format(today, 'yyyy-MM-dd'));
+    await user.type(screen.getByLabelText('To:'), format(tomorrow, 'yyyy-MM-dd'));
+    await user.type(screen.getByRole('slider', { name: 'Cloud Cover:' }), '50');
+
+    // Submit form
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    // Expect no validation errors
+    expect(screen.queryByText('Must be of format YYYY-MM-DD')).not.toBeInTheDocument();
+    expect(screen.queryByText('To data cannot be earlier than from date.')).not.toBeInTheDocument();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('SUBMIT FORM DATA: ', {
+      from: format(today, 'yyyy-MM-dd'),
+      to: format(tomorrow, 'yyyy-MM-dd'),
+      cloudCover: '100',
+      // Ensure these match your form data setup
+      dataSource: { value: 'pneo', label: 'PNeo' }, // Example values
+      itemType: { value: 'psscene', label: 'PSScene' },
+      productBundle: { value: 'visual', label: 'Visual (orthorectified)' },
+    });
+
+    // Clean up the spy
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should handle selection of data source, item type, and product bundle', async () => {
+    const user = userEvent.setup();
+    render(<QueryForm />);
+
+    // Use getAllByRole to find all comboboxes (multiple react-select components)
+    const comboboxes = screen.getAllByRole('combobox');
+    expect(comboboxes).toHaveLength(3);
+
+    // Interact with the first combobox (Data Source)
+    await user.click(comboboxes[0]);
+    await user.click(screen.getByText('Pleiades'));
+    expect(screen.getByText('Pleiades')).toBeInTheDocument();
+
+    // Interact with the second combobox (Item Type)
+    await user.click(comboboxes[1]);
+    await user.click(screen.getByText('SkySatCollect'));
+    expect(screen.getByText('SkySatCollect')).toBeInTheDocument();
+
+    // Interact with the second combobox (Product Bundle)
+    await user.click(comboboxes[2]);
+    await user.click(screen.getByText('General Use (orthorectified, panshapened)'));
+    expect(screen.getByText('General Use (orthorectified, panshapened)')).toBeInTheDocument();
+  });
+});

--- a/src/pages/MapViewer/components/Toolbox/components/purchases/QueryForm.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/purchases/QueryForm.tsx
@@ -1,0 +1,180 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { format } from 'date-fns';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { ZodType, z } from 'zod';
+
+import { FormField } from '@/components/form/FormField';
+import { RangeSliderField } from '@/components/form/RangeSliderField';
+import { SelectField } from '@/components/form/SelectField';
+import { SubmitButton } from '@/components/form/SubmitButton';
+
+type SelectData = {
+  value: string;
+  label: string;
+};
+
+type FormValues = {
+  from?: string;
+  to?: string;
+  dataSource: SelectData;
+  itemType: SelectData;
+  productBundle: SelectData;
+  cloudCover: string;
+};
+
+const DATE_REGEX = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
+
+const QueryFormSchema = z
+  .object({
+    from: z.string().regex(DATE_REGEX, { message: 'Must be of format YYYY-MM-DD' }),
+    to: z.string().regex(DATE_REGEX, { message: 'Must be of format YYYY-MM-DD' }),
+    dataSource: z.object({
+      label: z.string(),
+      value: z.string(),
+    }),
+    itemType: z.object({
+      label: z.string(),
+      value: z.string(),
+    }),
+    productBundle: z.object({
+      label: z.string(),
+      value: z.string(),
+    }),
+    cloudCover: z.string(),
+  })
+  .refine(({ from, to }) => to >= from, {
+    message: 'To date cannot be earlier than from date.',
+    path: ['from'],
+  }) as ZodType<FormValues>;
+
+const dataSources: SelectData[] = [
+  {
+    value: 'pneo',
+    label: 'PNeo',
+  },
+  {
+    value: 'pleiades',
+    label: 'Pleiades',
+  },
+  {
+    value: 'spot',
+    label: 'SPOT',
+  },
+  {
+    value: 'planetscope',
+    label: 'PlanetScope',
+  },
+  {
+    value: 'skysat',
+    label: 'SkySat',
+  },
+];
+
+const itemTypes: SelectData[] = [
+  {
+    value: 'psscene',
+    label: 'PSScene',
+  },
+  {
+    value: 'skysatcollect',
+    label: 'SkySatCollect',
+  },
+];
+
+const productBundles: SelectData[] = [
+  {
+    value: 'visual',
+    label: 'Visual (orthorectified)',
+  },
+  {
+    value: 'general',
+    label: 'General Use (orthorectified, panshapened)',
+  },
+  {
+    value: 'analytic',
+    label: 'Analytic (orthorectified, surface reflectance)',
+  },
+  {
+    value: 'basic',
+    label: 'Basic (orthorectified, top of atmosphere)',
+  },
+];
+
+const defaultValues: FormValues = {
+  from: null,
+  to: null,
+  dataSource: dataSources[0],
+  itemType: itemTypes[0],
+  productBundle: productBundles[0],
+  cloudCover: '100',
+};
+
+export const QueryForm = () => {
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    mode: 'onBlur',
+    resolver: zodResolver(QueryFormSchema),
+    defaultValues,
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => console.log('SUBMIT FORM DATA: ', data);
+
+  const today = format(new Date(), 'yyyy-MM-dd');
+
+  return (
+    <form className="form" onSubmit={handleSubmit(onSubmit)}>
+      <FormField<FormValues>
+        error={errors.from}
+        label="From:"
+        min={today}
+        name="from"
+        register={register}
+        type="date"
+      />
+
+      <FormField<FormValues>
+        error={errors.to}
+        label="To:"
+        min={today}
+        name="to"
+        register={register}
+        type="date"
+      />
+
+      <SelectField<FormValues>
+        control={control}
+        label="Data source:"
+        name="dataSource"
+        options={dataSources}
+      />
+
+      <SelectField<FormValues>
+        control={control}
+        label="Item type:"
+        name="itemType"
+        options={itemTypes}
+      />
+
+      <SelectField<FormValues>
+        control={control}
+        label="Product Bundle:"
+        name="productBundle"
+        options={productBundles}
+      />
+
+      <RangeSliderField<FormValues>
+        label="Cloud Cover:"
+        max={100}
+        min={0}
+        name="cloudCover"
+        register={register}
+      />
+
+      <SubmitButton>Search</SubmitButton>
+    </form>
+  );
+};

--- a/src/pages/MapViewer/components/Toolbox/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/index.tsx
@@ -1,22 +1,16 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { Suspense, lazy, useState } from 'react';
+import { useState } from 'react';
 
 import { Tooltip } from 'react-tooltip';
 
 import { useToolbox } from '@/hooks/useToolbox';
 
-// import { PurchaseFormPanel } from './components/purchases/PurchaseFormPanel';
+import { PurchaseFormPanel } from './components/purchases/PurchaseFormPanel';
 import ToolboxCollections from './components/ToolboxCollections';
 import ToolboxItems from './components/ToolboxItems';
 
 import './styles.scss';
-
-const PurchaseFormPanel = lazy(() =>
-  import('./components/purchases/PurchaseFormPanel').then((module) => ({
-    default: module.PurchaseFormPanel,
-  })),
-);
 
 const Toolbox: React.FC = () => {
   const [toolboxVisible, setToolboxVisible] = useState(true); // TODO: Move to context
@@ -32,11 +26,7 @@ const Toolbox: React.FC = () => {
       case 'items':
         return <ToolboxItems />;
       case 'purchase':
-        return (
-          <Suspense>
-            <PurchaseFormPanel />
-          </Suspense>
-        );
+        return <PurchaseFormPanel />;
       default:
         return <ToolboxCollections />;
     }

--- a/src/pages/MapViewer/components/Toolbox/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/index.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from 'react-tooltip';
 
 import { useToolbox } from '@/hooks/useToolbox';
 
+import { PurchaseFormPanel } from './components/purchases/PurchaseFormPanel';
 import ToolboxCollections from './components/ToolboxCollections';
 import ToolboxItems from './components/ToolboxItems';
 
@@ -24,6 +25,8 @@ const Toolbox: React.FC = () => {
         return <ToolboxCollections />;
       case 'items':
         return <ToolboxItems />;
+      case 'purchase':
+        return <PurchaseFormPanel />;
       default:
         return <ToolboxCollections />;
     }
@@ -34,7 +37,7 @@ const Toolbox: React.FC = () => {
       className={`toolbox ${toolboxVisible ? 'toolbox--visible' : 'toolbox--hidden'}`}
       id="toolbox"
     >
-      <div className="toolbox__window-actions">
+      <div className="handle toolbox__window-actions">
         <Tooltip id="window-tooltip" place="top-start" />
         <span
           className="toolbox__window-action"

--- a/src/pages/MapViewer/components/Toolbox/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/index.tsx
@@ -1,16 +1,22 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { useState } from 'react';
+import { Suspense, lazy, useState } from 'react';
 
 import { Tooltip } from 'react-tooltip';
 
 import { useToolbox } from '@/hooks/useToolbox';
 
-import { PurchaseFormPanel } from './components/purchases/PurchaseFormPanel';
+// import { PurchaseFormPanel } from './components/purchases/PurchaseFormPanel';
 import ToolboxCollections from './components/ToolboxCollections';
 import ToolboxItems from './components/ToolboxItems';
 
 import './styles.scss';
+
+const PurchaseFormPanel = lazy(() =>
+  import('./components/purchases/PurchaseFormPanel').then((module) => ({
+    default: module.PurchaseFormPanel,
+  })),
+);
 
 const Toolbox: React.FC = () => {
   const [toolboxVisible, setToolboxVisible] = useState(true); // TODO: Move to context
@@ -26,7 +32,11 @@ const Toolbox: React.FC = () => {
       case 'items':
         return <ToolboxItems />;
       case 'purchase':
-        return <PurchaseFormPanel />;
+        return (
+          <Suspense>
+            <PurchaseFormPanel />
+          </Suspense>
+        );
       default:
         return <ToolboxCollections />;
     }

--- a/src/pages/MapViewer/components/Toolbox/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/styles.scss
@@ -1,6 +1,9 @@
+@import '@/styles/main';
+
 .toolbox {
-  width: 400px;
-  height: 450px;
+  min-width: 450px;
+  max-width: 450px;
+  min-height: 550px;
   z-index: 99999;
   position: relative;
 
@@ -9,27 +12,31 @@
     box-sizing: border-box;
   }
 
+  & .handle {
+    background-color: $primary-colour;
+    cursor: pointer;
+  }
+
   &__window-actions {
     width: 100%;
     display: flex;
     justify-content: flex-end;
     gap: 10px;
-    top: 5px;
-    right: 5px;
-    position: fixed;
+    padding: 0.5rem;
 
     /* stylelint-disable-next-line selector-class-pattern */
     .toolbox__window-action {
       cursor: pointer;
       width: 20px;
       height: 20px;
-      border: 1px solid black;
+      border: 1px solid #fff;
       display: flex;
       justify-content: center;
       align-items: center;
       padding: 5px;
       border-radius: 15%;
       font-size: 10px;
+      color: #fff;
     }
   }
 

--- a/src/pages/MapViewer/index.tsx
+++ b/src/pages/MapViewer/index.tsx
@@ -70,7 +70,7 @@ const MapViewer = () => {
   return (
     <div className="map-viewer">
       <MapComponent>
-        <Draggable defaultPosition={{ x: 150, y: 150 }}>
+        <Draggable defaultPosition={{ x: 150, y: 150 }} handle=".handle">
           <div className="draggable">
             <Toolbox />
           </div>

--- a/src/typings/stac.ts
+++ b/src/typings/stac.ts
@@ -219,6 +219,7 @@ export type StacItem = GeoJSONFeature & {
 export type Feature = {
   id: string;
   type: 'Feature';
+  bbox: [number, number, number, number];
   geometry: {
     type: 'Polygon';
     coordinates: number[][][];


### PR DESCRIPTION
This PR covers ticket https://telespazio-uk.atlassian.net/browse/EODHP-629, which deals with the UI for purchasing commercial data. Right now we don't have access to any and I expect the UI to go through a major re-design very soon, so I didn't want to change to much. Rather, I have agreed with Alasdair that we can use the current collection items and treat them as commercial. Therefore, when you click on a collection item, not only does the geometry of the item get rendered on the map, but now the list of items is replaced with Accordion panels representing the forms that would be used:

1. A form to search the commercial data for scenes/items
2. A form to purchase selected scene/item

Again, we don't have anywhere to send the forms to, so right now when the form is submitted and is in a valid state, then the form contents are logged to the console. Once we have APIs to use, the submit actions will be fleshed out to post the data. This may also require some refactoring of the forms, but there is too little information to go to say more and the more we code, the more is going to just be thrown away.

The forms use common client-side libraries to manage form i.e. [react-hook-form](https://react-hook-form.com/) to manage the forms themselves, along with [zod](https://zod.dev/) to manage validation of the form. I've also added a couple of other libraries for common components and then wrapped them into re-usable components for our app e.g. `FormField`, `SelectField` and `RangeSliderField`.

I also noticed the build is starting to get larger than what vite recommends, vite splits the code into chunks where it can, but we can also help it by lazily loading code, which is what I've done in the very last commit.