### PR TITLE
628 UI spillover

### DIFF
--- a/src/pages/DataCatalogue/components/DataCatalogueTable/styles.scss
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/styles.scss
@@ -6,6 +6,8 @@
   margin-top: 0.5rem;
   font-size: 0.85rem;
   border-top: 1px solid black;
+  overflow-y: auto;
+  height: 90%;
 
   table {
     width: 100%;

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxCollections/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxCollections/styles.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable-next-line selector-class-pattern */
 .toolbox__collections {
-  height: 100%;
+  height: 550px;
   overflow-y: auto;
 }

--- a/src/pages/MapViewer/components/Toolbox/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/styles.scss
@@ -1,11 +1,8 @@
 @import '@/styles/main';
 
 .toolbox {
-  min-width: 450px;
-  max-width: 450px;
-  min-height: 550px;
+  width: 450px;
   z-index: 99999;
-  position: relative;
 
   &-content-container {
     height: 100%;
@@ -41,9 +38,8 @@
   }
 
   &__content {
-    position: relative;
-    margin-top: 27px;
     height: 100%;
+    overflow-y: auto;
   }
 
   &--hidden {


### PR DESCRIPTION
I've updated the component styling for the:

- Data Catalogue
- Toolbox

This new styling prevents the lists for spilling over down past the footer of the page.