### PR TITLE
Redirect to sign in on 401 Unauthorized response

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
-VITE_STAC_ENDPOINT=https://test.eodatahub.org.uk/api/catalogue/stac
+VITE_STAC_ENDPOINT=/api/catalogue/stac
+VITE_SIGN_IN=/sign_in/
 VITE_STAC_BROWSER=https://radiantearth.github.io/stac-browser                           # tmp var until resource catalogue UI matures
 

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -103,14 +103,18 @@ const getStacCatalogUrl = (collection: Collection): string => {
   const selfLink = collection.links.find((link) => link.rel === 'self');
   if (!selfLink?.href) return '';
 
-  // Extract central part of URL, so take:
-  // `https://test.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/ceda-stac-fastapi/collections/cmip6`
-  // and return `supported-datasets/ceda-stac-fastapi`.
-  const catalogsStr = '/catalogs/';
-  const start = selfLink.href.indexOf(catalogsStr) + catalogsStr.length;
-  const end = selfLink.href.indexOf('/collections/');
-  const catalogUrl = selfLink.href.slice(start, end);
+  const index =
+    selfLink.href.indexOf(import.meta.env.VITE_STAC_ENDPOINT) +
+    import.meta.env.VITE_STAC_ENDPOINT.length;
 
+  // Remove everything up to the end of the Env Var `VITE_STAC_ENDPOINT`.
+  let url = selfLink.href.slice(index, selfLink.href.length);
+
+  if (url.startsWith('/catalogs/')) {
+    url = url.replace('/catalogs/', '');
+  }
+
+  const [catalogUrl] = url.split('/collections/');
   return catalogUrl;
 };
 

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -7,7 +7,6 @@ import landsat from '@/assets/placeholders/landsat.png';
 import sentinel2 from '@/assets/placeholders/sentinel-2.png';
 import terraclimate from '@/assets/placeholders/terraclimate.png';
 import { Collection } from '@/typings/stac';
-import { AppUrls } from '@/utils/appUrls';
 import { formatDateAsISO8601 } from '@/utils/genericUtils';
 import { HttpCodes } from '@/utils/http';
 
@@ -37,8 +36,8 @@ export const getStacCollections = async (
     });
 
     if (!response.ok) {
-      if (response.status === HttpCodes.FORBIDDEN) {
-        window.location.href = AppUrls.SIGN_IN;
+      if (response.status === HttpCodes.UNAUTHORIZED) {
+        window.location.href = import.meta.env.VITE_SIGN_IN;
       } else {
         throw new Error('Network response was not ok');
       }
@@ -104,12 +103,14 @@ const getStacCatalogUrl = (collection: Collection): string => {
   const selfLink = collection.links.find((link) => link.rel === 'self');
   if (!selfLink?.href) return '';
 
-  let url = selfLink.href.replace(import.meta.env.VITE_STAC_ENDPOINT, '');
-  if (url.startsWith('/catalogs/')) {
-    url = url.replace('/catalogs/', '');
-  }
+  // Extract central part of URL, so take:
+  // `https://test.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/ceda-stac-fastapi/collections/cmip6`
+  // and return `supported-datasets/ceda-stac-fastapi`.
+  const catalogsStr = '/catalogs/';
+  const start = selfLink.href.indexOf(catalogsStr) + catalogsStr.length;
+  const end = selfLink.href.indexOf('/collections/');
+  const catalogUrl = selfLink.href.slice(start, end);
 
-  const [catalogUrl] = url.split('/collections/');
   return catalogUrl;
 };
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,3 +1,3 @@
 export enum HttpCodes {
-  FORBIDDEN = 403,
+  UNAUTHORIZED = 401,
 }


### PR DESCRIPTION
Now that we can configure the Resource catalogue with the path to a private catalog, it is possible to get a 401 Unauthorized response. This means the user is not logged in.

If we get this response, then we redirect to the sign in page, so the user can sign in. Once that happens, they should be redirected back to the catalogue with the exact same URL, the left from.

There are issues with this solution from a local development point of view, you can't configure it to use say `dev` to login, then have all the session info work for `localhost` as well. This is a limitation of our current setup, the only way we can see to work around this is to have more of the whole system able to run locally.

IssueID EODHP-811