### PR TITLE
836 static element interactions

### DIFF
--- a/src/pages/DataCatalogue/components/DataCatalogueTable/index.tsx
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/index.tsx
@@ -29,8 +29,7 @@ const DataCatalogueTable: React.FC = () => {
       </div>
       {items.map((row) => {
         return (
-          // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-          <div
+          <button
             key={row.id}
             className="data-catalogue-table__row"
             onClick={() => {
@@ -50,7 +49,7 @@ const DataCatalogueTable: React.FC = () => {
             <div className="data-catalogue-table__row-type">
               <span>{row.type}</span>
             </div>
-          </div>
+          </button>
         );
       })}
       {collectionSearchResults?.length === 0 && (

--- a/src/pages/DataCatalogue/components/DataCatalogueTable/styles.scss
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/styles.scss
@@ -29,6 +29,8 @@
     display: flex;
     padding: 0.5rem 0;
     cursor: pointer;
+    width: 100%;
+    border: unset;
 
     &:hover {
       background-color: $hover-colour;
@@ -49,6 +51,7 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
+      align-items: flex-start;
       padding: 0.25rem 0.5rem;
 
       span {

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { Feature } from 'ol';
 import { Polygon } from 'ol/geom';
 import { Vector as VectorLayer } from 'ol/layer';
@@ -45,14 +43,14 @@ const ToolboxItems = () => {
     <div className="toolbox-content-container">
       {/* This header could be its own component, can't see where it would be used though */}
       <div className="toolbox__header">
-        <div
+        <button
           className="toolbox__header-back"
           onClick={() => {
             setActivePage('collections');
           }}
         >
           <span>&lt; Return to Collections</span>
-        </div>
+        </button>
         <div className="toolbox__header-title">
           {selectedCollection.title ? selectedCollection.title : selectedCollection.id}
         </div>
@@ -68,7 +66,7 @@ const ToolboxItems = () => {
               dataPoints={parseFeatureDataPoints(item)}
               thumbnail={returnFeatureThumbnail(item)}
               title={item.id.toString()}
-              onClick={(e) => {
+              onClick={() => {
                 setActivePage('assets');
                 setSelectedCollectionItem(item);
 
@@ -108,12 +106,6 @@ const ToolboxItems = () => {
 
                 // Zoom the map to the buffered extent of the scene.
                 map.getView().fit(polygon.getGeometry(), { padding: [20, 20, 20, 20] });
-
-                if (e.shiftKey) {
-                  if (url) {
-                    window.open(url, '_blank');
-                  }
-                }
               }}
             >
               <div className="button-wrapper">

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
@@ -1,4 +1,9 @@
-/* stylelint-disable-next-line selector-class-pattern */
+/* stylelint-disable selector-class-pattern */
+.toolbox__header-back {
+  display: flex;
+  border: unset;
+}
+
 .toolbox__items {
   overflow-y: auto;
   height: calc(100% - 50px);

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/index.tsx
@@ -6,8 +6,7 @@ import './styles.scss';
 
 const ToolboxRow = ({ thumbnail, title, dataPoints, onClick, children }: ToolboxItemProps) => {
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-    <div className="toolbox-row" onClick={onClick}>
+    <button className="toolbox-row" onClick={onClick}>
       <div className="toolbox-row__left">
         <img
           alt="thumbnail"
@@ -29,7 +28,7 @@ const ToolboxRow = ({ thumbnail, title, dataPoints, onClick, children }: Toolbox
         ))}
         {children ? children : null}
       </div>
-    </div>
+    </button>
   );
 };
 

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
@@ -6,6 +6,7 @@
   padding: 10px;
   cursor: pointer;
   align-items: center;
+  border: unset;
 
   &:hover {
     background-color: $hover-colour;
@@ -42,6 +43,7 @@
       font-size: 0.875rem;
       word-wrap: break-word;
       overflow: hidden;
+      text-align: left;
     }
 
     /* stylelint-disable-next-line selector-class-pattern */

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/types.ts
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/types.ts
@@ -4,7 +4,7 @@ export interface ToolboxItemProps {
   thumbnail: string;
   title: string;
   dataPoints?: DataPoint[];
-  onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onClick: () => void;
   children?: ReactNode;
 }
 

--- a/src/pages/MapViewer/components/Toolbox/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/index.tsx
@@ -36,7 +36,11 @@ const Toolbox: React.FC = () => {
   return (
     <div className={`toolbox`} id="toolbox">
       <div className="handle toolbox__window-actions">
-        <button className="minimize" onClick={() => setToolboxVisible((prev) => !prev)}>
+        <button
+          aria-label="minimize toolbox dialog"
+          className="minimize"
+          onClick={() => setToolboxVisible((prev) => !prev)}
+        >
           <FaRegWindowMinimize />
         </button>
       </div>


### PR DESCRIPTION
In this PR I'm swapping out clickable `div` elements for `button` elements. 

Clickable `div` elements are not bad per se, but from an accessibility point of view they need to be managed, so adding `tabindex` `onKeyUp` event handler etc. The accessibility recommendation is to use buttons and fix their styling to what you need, wherever possible, so that is what I have done here.

Mostly the changes involve removing default button styling like `borders` and maybe positioning text to be left-aligned. I also remove the `key` events as buttons already manage the `enter` and `spacebar` keys when focused.

There are no tests for these components, there should be, but I'm not sure this PR to fix interaction should be where they are introduced. We lack a lot of tests in this codebase and it is something I'm adding when adding new features, I've not gone back to add tests for components that already exist, that should probably be a ticket in it's own right.