### PR TITLE
Calculating resource catalogue height based off header and footer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>EODHP Resource Catalogue</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="resource-catalogue-ui"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,7 +11,7 @@
 .main {
   width: 100%;
   display: flex;
-  height: 100vh;
+  height: calc(100vh - 130px - 100px);
   min-height: 450px;
   max-height: 750px;
   position: relative;

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,7 +11,7 @@
 .main {
   width: 100%;
   display: flex;
-  height: calc(100vh - 130px - 100px);
+  height: 100%;
   min-height: 450px;
   max-height: 750px;
   position: relative;

--- a/src/index.scss
+++ b/src/index.scss
@@ -13,7 +13,6 @@
   display: flex;
   height: 100%;
   min-height: 450px;
-  max-height: 750px;
   position: relative;
 
   .left-sidebar-container {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,7 +29,7 @@ const enableMocking = async () => {
   });
 };
 
-const rootElement = document.getElementById('root');
+const rootElement = document.getElementById('resource-catalogue-ui');
 if (!rootElement) throw new Error('Failed to find the root element');
 
 const root = ReactDOM.createRoot(rootElement);


### PR DESCRIPTION
Having discussed this with Mark, I tried using flex-grow to make the sidebar and map use the available space, having already set the header and footer to be a fit height in the web-presence.

This did not work as the sidebar was too large and growing outside of the window height. After discussion with Mark, we decided to calculate the view height and subtract the height of the footer and header. 

The downside to this is that their is a tight coupling between the header and the footer in the web-presence and the height calculated here, thus if the height of the header or footer ever changes, this value will need to be changes also.

@marksmall 

https://telespazio-uk.atlassian.net/jira/software/c/projects/EODHP/boards/3?selectedIssue=EODHP-848