### PR TITLE
888 map button tooltips

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -6,6 +6,7 @@ import { ScaleLine, defaults as defaultControls } from 'ol/control';
 import { Tile as TileLayer } from 'ol/layer';
 import { fromLonLat } from 'ol/proj';
 import { OSM } from 'ol/source';
+import { Tooltip } from 'react-tooltip';
 
 import { useMap } from '@/hooks/useMap';
 
@@ -59,6 +60,28 @@ export const MapComponent = ({ children }: MapComponentProps) => {
 
     setMap(map);
 
+    const attachTooltips = () => {
+      const zoomInButton = document.querySelector('.ol-zoom-in');
+      const zoomOutButton = document.querySelector('.ol-zoom-out');
+
+      if (zoomInButton) {
+        // Remove default title, so we don't get duplicate tooltips.
+        zoomInButton.removeAttribute('title');
+
+        zoomInButton.setAttribute('data-tooltip-content', 'Zoom In');
+      }
+
+      if (zoomOutButton) {
+        // Remove default title, so we don't get duplicate tooltips.
+        zoomOutButton.removeAttribute('title');
+
+        zoomOutButton.setAttribute('data-tooltip-content', 'Zoom Out');
+      }
+    };
+
+    // Wait for DOM rendering before attaching tooltips
+    setTimeout(attachTooltips, 0);
+
     return () => {
       map?.setTarget(undefined);
     };
@@ -69,6 +92,7 @@ export const MapComponent = ({ children }: MapComponentProps) => {
       <div ref={mapRef} className="flex-grow" id="map">
         {children}
       </div>
+      <Tooltip anchorSelect=".ol-zoom-in, .ol-zoom-out" place="right" />
     </div>
   );
 };

--- a/src/components/map/draw-tools/DrawingTools.test.tsx
+++ b/src/components/map/draw-tools/DrawingTools.test.tsx
@@ -51,15 +51,13 @@ describe('DrawingTools', () => {
     render(<DrawingTools />);
 
     // Check that the button is rendered
-    expect(
-      screen.getByRole('button', { name: /display drawing tools panel/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /map drawing tools/i })).toBeInTheDocument();
   });
 
   it('should toggle the DrawingToolbox visibility when the button is clicked', async () => {
     render(<DrawingTools />);
 
-    const button = screen.getByRole('button', { name: /display drawing tools panel/i });
+    const button = screen.getByRole('button', { name: /map drawing tools/i });
 
     // DrawingToolbox should not be visible initially
     const toolbox = screen.queryByRole('region', { name: /drawing-toolbox/i });

--- a/src/components/map/draw-tools/DrawingTools.tsx
+++ b/src/components/map/draw-tools/DrawingTools.tsx
@@ -51,9 +51,9 @@ export const DrawingTools = () => {
       <Tooltip id="drawTools" />
 
       <button
-        aria-label="display drawing tools panel"
+        aria-label="Map Drawing Tools"
         className="bbox"
-        data-tooltip-content="display drawing tools panel"
+        data-tooltip-content="Map Drawing tools"
         data-tooltip-id="drawTools"
         onClick={() => setIsDrawingToolboxVisible((prev) => !prev)}
       >

--- a/src/pages/MapViewer/index.tsx
+++ b/src/pages/MapViewer/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import Draggable from 'react-draggable';
 import { FaTable } from 'react-icons/fa6';
 import { VscPreview } from 'react-icons/vsc';
+import { Tooltip } from 'react-tooltip';
 
 import stacBrowserLogo from '@/assets/icons/stac-browser.png';
 import { MapComponent } from '@/components/Map';
@@ -23,6 +24,8 @@ const MapViewer = () => {
   return (
     <div className="map-viewer">
       <MapComponent>
+        <Tooltip id="map-buttons" />
+
         <Draggable defaultPosition={{ x: 150, y: 150 }} handle=".handle" nodeRef={nodeRef}>
           <div ref={nodeRef} className="draggable">
             <Toolbox />
@@ -34,16 +37,26 @@ const MapViewer = () => {
       <button
         aria-label="Data Catalogue"
         className="table-view-icon"
+        data-tooltip-content="View Data Catalogue"
+        data-tooltip-id="map-buttons"
         onClick={() => setActiveContent('dataCatalogue')}
       >
         <FaTable />
       </button>
-      <button aria-label="QA Panel" className="qa-view-icon" onClick={() => setActiveContent('qa')}>
+      <button
+        aria-label="QA Panel"
+        className="qa-view-icon"
+        data-tooltip-content="View Q&A"
+        data-tooltip-id="map-buttons"
+        onClick={() => setActiveContent('qa')}
+      >
         <VscPreview />
       </button>
       <button
         aria-label="STAC Browser"
         className="btn-stac-browser unstyled-button"
+        data-tooltip-content="Open in STAC Browser"
+        data-tooltip-id="map-buttons"
         onClick={() =>
           window.open(
             `${import.meta.env.VITE_STAC_BROWSER}/#/external/${import.meta.env.VITE_STAC_ENDPOINT}`,

--- a/src/pages/MapViewer/styles.scss
+++ b/src/pages/MapViewer/styles.scss
@@ -3,6 +3,10 @@
   flex-grow: 4;
   height: 100%;
 
+  #map-buttons {
+    z-index: 100;
+  }
+
   .draggable {
     position: absolute;
     z-index: 9999;


### PR DESCRIPTION
I have now overridden the default tooltips used by openlayers for the zoom in/out buttons to use react-tooltip styling, for consistency and added tooltips to all the buttons on the top-right of the map.