### PR TITLE
Improve styling of map buttons

### DIFF
--- a/src/pages/MapViewer/index.tsx
+++ b/src/pages/MapViewer/index.tsx
@@ -34,38 +34,41 @@ const MapViewer = () => {
         <TimelineFilter />
       </MapComponent>
 
-      <button
-        aria-label="Data Catalogue"
-        className="table-view-icon"
-        data-tooltip-content="View Data Catalogue"
-        data-tooltip-id="map-buttons"
-        onClick={() => setActiveContent('dataCatalogue')}
-      >
-        <FaTable />
-      </button>
-      <button
-        aria-label="QA Panel"
-        className="qa-view-icon"
-        data-tooltip-content="View Q&A"
-        data-tooltip-id="map-buttons"
-        onClick={() => setActiveContent('qa')}
-      >
-        <VscPreview />
-      </button>
-      <button
-        aria-label="STAC Browser"
-        className="btn-stac-browser unstyled-button"
-        data-tooltip-content="Open in STAC Browser"
-        data-tooltip-id="map-buttons"
-        onClick={() =>
-          window.open(
-            `${import.meta.env.VITE_STAC_BROWSER}/#/external/${import.meta.env.VITE_STAC_ENDPOINT}`,
-            '_blank',
-          )
-        }
-      >
-        <img alt="STAC Browser" src={stacBrowserLogo} />
-      </button>
+      <div className="horizontal">
+        <button
+          aria-label="STAC Browser"
+          className="btn-stac-browser unstyled-button"
+          data-tooltip-content="Open in STAC Browser"
+          data-tooltip-id="map-buttons"
+          onClick={() =>
+            window.open(
+              `${import.meta.env.VITE_STAC_BROWSER}/#/external/${import.meta.env.VITE_STAC_ENDPOINT}`,
+              '_blank',
+            )
+          }
+        >
+          <img alt="STAC Browser" src={stacBrowserLogo} />
+        </button>
+      </div>
+
+      <div className="vertical">
+        <button
+          aria-label="Data Catalogue"
+          data-tooltip-content="View Data Catalogue"
+          data-tooltip-id="map-buttons"
+          onClick={() => setActiveContent('dataCatalogue')}
+        >
+          <FaTable />
+        </button>
+        <button
+          aria-label="QA Panel"
+          data-tooltip-content="View Q&A"
+          data-tooltip-id="map-buttons"
+          onClick={() => setActiveContent('qa')}
+        >
+          <VscPreview />
+        </button>
+      </div>
 
       <DrawingTools />
     </div>

--- a/src/pages/MapViewer/styles.scss
+++ b/src/pages/MapViewer/styles.scss
@@ -12,69 +12,54 @@
     z-index: 9999;
     background-color: rgb(240 240 240 / 90%); // TODO: Find branding colour
   }
+
+  .horizontal {
+    position: absolute;
+    top: 8.5px;
+    right: 55px;
+    display: flex;
+
+    .btn-stac-browser {
+      padding: 2px;
+      height: 34px;
+      width: 34px;
+      cursor: pointer;
+
+      img {
+        width: 100%;
+        border-radius: 10%;
+      }
+    }
+  }
+
+  .vertical {
+    position: absolute;
+    top: 8.5px;
+    right: 12px;
+    display: flex;
+    flex-direction: column;
+
+    button {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background-color: white;
+      border-radius: 10%;
+      padding: 5px;
+      border: 2px solid rgb(0 0 0 / 20%);
+      cursor: pointer;
+
+      svg {
+        align-self: center;
+        font-size: 20px;
+      }
+    }
+  }
 }
 
 .flex-grow {
   display: flex;
   flex-grow: 1;
   width: 100%;
-}
-
-.table-view-icon {
-  position: absolute;
-  top: 8.5px;
-  right: 12px;
-  background-color: white;
-  border-radius: 10%;
-  padding: 5px;
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  border: 2px solid rgb(0 0 0 / 20%);
-  cursor: pointer;
-
-  svg {
-    align-self: center;
-    font-size: 20px;
-  }
-}
-
-.qa-view-icon {
-  position: absolute;
-  top: 58.5px;
-  right: 12px;
-  background-color: white;
-  border-radius: 10%;
-  padding: 5px;
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  border: 2px solid rgb(0 0 0 / 20%);
-  cursor: pointer;
-
-  svg {
-    align-self: center;
-    font-size: 20px;
-  }
-}
-
-.btn-stac-browser {
-  position: absolute;
-  top: 8.5px;
-  right: 55px;
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  padding: 2px;
-  height: 34px;
-  width: 34px;
-
-  img {
-    align-self: center;
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-    cursor: pointer;
-    border-radius: 10%;
-  }
 }


### PR DESCRIPTION
Right now all the buttons placed themselves at specific locations on the map. This I feel can be simplified by having a `horizontal` and `vertical` panels, then any button can be added to either and they organize themselves, reducing the styling needed. Of course if any button had it's own requirements e.g. bigger, placed a bit further away from others, it can still be displayed like buttons are now, outwith either of these panels.

@james-hinton I've assigned this to Isaac, but feel free to comment if you wish.

IssueID EODHP-910