### PR TITLE
844 list view pagination

### DIFF
--- a/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRow.test.tsx
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRow.test.tsx
@@ -32,7 +32,7 @@ describe('DataCatalogueRow', () => {
   it('should render loading state initially', () => {
     render(<DataCatalogueRow row={mockRow} />);
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('should render row data after fetching parent data', async () => {

--- a/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRow.tsx
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRow.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import { Collection } from '@/typings/stac';
 
+import { DataCatalogueRowSkeleton } from './DataCatalogueRowSkeleton';
+
 type DataCatalogueRowProps = {
   row: Collection;
 };
@@ -50,7 +52,7 @@ export const DataCatalogueRow = ({ row }: DataCatalogueRowProps) => {
   }, [row]);
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <DataCatalogueRowSkeleton />;
   }
 
   return (
@@ -68,7 +70,7 @@ export const DataCatalogueRow = ({ row }: DataCatalogueRowProps) => {
             <span>
               Parent Catalogue:{' '}
               {breadcrumb.map((parent, index) => (
-                <span key={parent.id}>
+                <span key={`${parent.id}-${row.id}`}>
                   {parent.title !== '' ? parent.title : parent.id}
                   {index < breadcrumb.length - 1 && ' > '}
                 </span>

--- a/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRowSkeleton.scss
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRowSkeleton.scss
@@ -1,0 +1,33 @@
+.skeleton-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 86px 16px 16px;
+  border-bottom: 1px solid #ddd;
+
+  .skeleton-content {
+    flex: 1;
+  }
+
+  .skeleton {
+    background-color: #fff;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    display: inline-block;
+    height: 20px;
+    width: 100%;
+    animation: pulse 1.5s infinite ease-in-out;
+  }
+
+  .skeleton-thumbnail {
+    width: 100px;
+    height: 100px;
+    background-color: #e0e0e0;
+    border-radius: 4px;
+    margin: 0 40px;
+    animation: pulse 1.5s infinite ease-in-out;
+  }
+
+  .skeleton-type {
+    width: 50px;
+  }
+}

--- a/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRowSkeleton.tsx
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/DataCatalogueRowSkeleton.tsx
@@ -1,0 +1,17 @@
+import './DataCatalogueRowSkeleton.scss';
+
+export const DataCatalogueRowSkeleton = () => {
+  return (
+    <output aria-busy="true" className="skeleton-row">
+      <div className="skeleton-content">
+        <div className="skeleton" />
+        <div className="skeleton" />
+        <div className="skeleton" />
+        <div className="skeleton" />
+      </div>
+
+      <div className="skeleton-thumbnail" />
+      <div className="skeleton-type skeleton" />
+    </output>
+  );
+};

--- a/src/pages/DataCatalogue/components/DataCatalogueTable/index.tsx
+++ b/src/pages/DataCatalogue/components/DataCatalogueTable/index.tsx
@@ -29,7 +29,7 @@ const DataCatalogueTable: React.FC = () => {
         ) : null}
       </div>
       {items.map((row) => (
-        <DataCatalogueRow key={row.id} row={row} />
+        <DataCatalogueRow key={`${row.id}-${row.lastUpdated}`} row={row} />
       ))}
 
       {collectionSearchResults?.length === 0 && (


### PR DESCRIPTION
The ticket for this PR is: https://telespazio-uk.atlassian.net/browse/EODHP-844

There is a bug, if you:

1. Go to https://test.eodatahub.org.uk/catalogue/ 
2. Click the top-right button to show the Data Catalogue list view.
3. Notice there are 6 entries.
4. Click the `next` button to see page 2.
5. Notice there are more than 6 (it should always only be 6).
6. Click back to page one and again there are more, there also seems to be duplicates etc.

While investigating this I found I was getting key duplicates when rendering the list of collections, so I've made the key more unique by using the timestamp of the collection part of the key and that stopped it from happening.

The next commit is about adding a loading skeleton instead of a basic `Loading...` message.