### PR TITLE
fix(toolbox): Display toolbox in Safari properly

### DIFF
--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
@@ -14,7 +14,6 @@
 
   &__left {
     width: 120px;
-    height: -webkit-fill-available;
     max-height: 100%;
     display: flex;
     justify-content: center;
@@ -23,8 +22,6 @@
     img {
       height: 100px;
       width: 100px;
-
-      // height: -webkit-fill-available;
       border: 1px solid black;
       object-fit: cover;
     }


### PR DESCRIPTION
The cause of this issue was the styling specifying a webkit specific setting, even though webkit is the engine used by safari. Removing it fixed the problem for me during triage, it maybe worked at some point but maybe other styling since then broke it. Its easy to happen if we don't invest in testing against multiple browsers in an automated way.

I have deployed this to the `dev` environment, the only way I was able to test this was using an IPad, I had no means of accessing a recent version of Safari.

IssueID EODHP-816