### PR TITLE
Sort spatial filtering on back link

### DIFF
--- a/src/components/tree/utils.ts
+++ b/src/components/tree/utils.ts
@@ -30,11 +30,14 @@ const filterByTemporal = (node: Collection, activeFilters: FilterActiveFilters) 
 
 const filterBySpatial = (node: Collection, activeFilters: FilterActiveFilters) => {
   const { bbox } = node.extent.spatial;
-  const collectionPolygon = bboxPolygon([bbox[0][0], bbox[0][1], bbox[0][2], bbox[0][3]]);
 
-  if (activeFilters.aoi.type === 'Polygon') {
-    const filterPolygon = polygon(activeFilters.aoi.coordinates);
-    return booleanIntersects(collectionPolygon, filterPolygon);
+  if (bbox.length !== 0) {
+    const collectionPolygon = bboxPolygon([bbox[0][0], bbox[0][1], bbox[0][2], bbox[0][3]]);
+
+    if (activeFilters.aoi.type === 'Polygon') {
+      const filterPolygon = polygon(activeFilters.aoi.coordinates);
+      return booleanIntersects(collectionPolygon, filterPolygon);
+    }
   }
 
   return true;


### PR DESCRIPTION
The ticket for this is at: https://telespazio-uk.atlassian.net/browse/EODHP-981

If you have filtered catalogs/collections and select a collection, then click the link to go back to the treeview, we lost the nodes `bbox`, the UI just sits there saying `loading...`. I have added a guard clause to only filter by spatial bbox if there actually is a bbox to filter by ie. not just an empty array.

IssueID EODHP-981