### PR TITLE
Use our version of the STAC Browser

### DIFF
--- a/src/pages/MapViewer/index.tsx
+++ b/src/pages/MapViewer/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import Draggable from 'react-draggable';
 import { FaTable } from 'react-icons/fa6';
 import { VscPreview } from 'react-icons/vsc';
+import { useLocation } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
 
 import stacBrowserLogo from '@/assets/icons/stac-browser.png';
@@ -17,9 +18,14 @@ import './styles.scss';
 
 const MapViewer = () => {
   const nodeRef = useRef(null);
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
+  const catalogPath = searchParams.get('catalogPath');
 
   const { actions: AppActions } = useApp();
   const { setActiveContent } = AppActions;
+
+  const stacBrowserUrl = `https://${window.location.host}/static-apps/stac-browser/main/index.html#/${import.meta.env.VITE_STAC_ENDPOINT}/${catalogPath ? 'catalogs/' + catalogPath : ''}`;
 
   return (
     <div className="map-viewer">
@@ -40,12 +46,7 @@ const MapViewer = () => {
           className="btn-stac-browser unstyled-button"
           data-tooltip-content="Open in STAC Browser"
           data-tooltip-id="map-buttons"
-          onClick={() =>
-            window.open(
-              `${import.meta.env.VITE_STAC_BROWSER}/#/external/${import.meta.env.VITE_STAC_ENDPOINT}`,
-              '_blank',
-            )
-          }
+          onClick={() => window.open(stacBrowserUrl, '_blank')}
         >
           <img alt="STAC Browser" src={stacBrowserLogo} />
         </button>


### PR DESCRIPTION
The ticket for this is: https://telespazio-uk.atlassian.net/browse/EODHP-971

I have switched over from Radiant Earth's STAC Browser to our own. 

### Testing

1. Go to the catalog in `dev`.
2. Click the greenish button in to top-right of the map, it's tooltip is `Open in STAC Browser`.
3. A new tab should open and you see a number of catalogs.

I will show you this working for Private Catalogs also, since you don't have one, but it might be best getting the likes of Tom Jellicoe to create one for you as you will need one to test various aspects of the UI.