### PR TITLE
934 date management

### DIFF
--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -7,8 +7,10 @@ import landsat from '@/assets/placeholders/landsat.png';
 import sentinel2 from '@/assets/placeholders/sentinel-2.png';
 import terraclimate from '@/assets/placeholders/terraclimate.png';
 import { Collection } from '@/typings/stac';
+import { extractDates } from '@/utils/date';
 import { formatDateAsISO8601 } from '@/utils/genericUtils';
 import { HttpCodes } from '@/utils/http';
+import { getStacDate } from '@/utils/stacUtils';
 
 import { StacCollectionsResponse } from './types';
 
@@ -46,8 +48,9 @@ export const getStacCollections = async (
 
     // For each data.collections add a thumbnailUrl, none of collections in the response have these fields
     data.collections.forEach((collection) => {
+      const dates = extractDates(collection);
       collection.thumbnailUrl = getRandomImage();
-      collection.lastUpdated = getRandomDate();
+      collection.lastUpdated = getStacDate(dates);
       collection.stacUrl = getStacUrl(collection);
     });
     return data.collections;
@@ -142,11 +145,4 @@ const getStacUrl = (collection: Collection): string => {
 const getRandomImage = () => {
   const images = [hgb, landsat, sentinel2, terraclimate];
   return images[Math.floor(Math.random() * images.length)];
-};
-
-// Temporary function to return random last updated date
-const getRandomDate = (): string => {
-  const date = new Date();
-  date.setDate(date.getDate() - Math.floor(Math.random() * 100));
-  return date.toISOString().split('T')[0];
 };

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -10,7 +10,7 @@ import { Collection } from '@/typings/stac';
 import { extractDates } from '@/utils/date';
 import { formatDateAsISO8601 } from '@/utils/genericUtils';
 import { HttpCodes } from '@/utils/http';
-import { getStacDate } from '@/utils/stacUtils';
+import { getFormattedSTACDateStr } from '@/utils/stacUtils';
 
 import { StacCollectionsResponse } from './types';
 
@@ -50,7 +50,7 @@ export const getStacCollections = async (
     data.collections.forEach((collection) => {
       const dates = extractDates(collection);
       collection.thumbnailUrl = getRandomImage();
-      collection.lastUpdated = getStacDate(dates);
+      collection.lastUpdated = getFormattedSTACDateStr(dates);
       collection.stacUrl = getStacUrl(collection);
     });
     return data.collections;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,24 +13,12 @@ export const formatDate = (date: string | Date, formatStr = DEFAULT_DATE_FORMAT)
   }
 };
 
-type Asset = {
-  datetime?: string;
-  created?: string;
-  updated?: string;
-  start_datetime?: string;
-  end_datetime?: string;
-};
-
 type StacData = Collection | StacItem;
 
 export type ExtractedDates = {
   start: string | null;
   end: string | null;
   datetime: string | null;
-  created: string | null;
-  updated: string | null;
-  start_datetime: string | null;
-  end_datetime: string | null;
 };
 
 export const extractDates = (stacData: StacData): ExtractedDates => {
@@ -38,36 +26,23 @@ export const extractDates = (stacData: StacData): ExtractedDates => {
     start: null,
     end: null,
     datetime: null,
-    created: null,
-    updated: null,
-    start_datetime: null,
-    end_datetime: null,
   };
 
   // Handle Collection temporal extent
   if (stacData.type === 'Collection') {
-    const temporalExtent = stacData?.extent?.temporal?.interval?.[0]; // First interval
+    const temporalExtent = stacData?.extent?.temporal?.interval?.[0];
     if (temporalExtent) {
-      dates.start = temporalExtent[0] || null;
-      dates.end = temporalExtent[1] || null;
+      if (temporalExtent[0]) dates.start = formatDate(temporalExtent[0]);
+      if (temporalExtent[1]) dates.end = formatDate(temporalExtent[1]);
     }
   }
 
   // Handle Item datetime in properties
   if (stacData.type === 'Feature') {
-    dates.start = stacData.properties.datetime || stacData.properties.start_datetime || null;
-    dates.end = stacData.properties.end_datetime || null;
-  }
-
-  // Handle assets (in both Collection and Item)
-  if (stacData.assets) {
-    Object.values(stacData.assets).forEach((asset: Asset) => {
-      dates.datetime = asset.datetime || dates.datetime;
-      dates.created = asset.created || dates.created;
-      dates.updated = asset.updated || dates.updated;
-      dates.start_datetime = asset.start_datetime || dates.start_datetime;
-      dates.end_datetime = asset.end_datetime || dates.end_datetime;
-    });
+    const props = stacData.properties;
+    if (props.datetime) dates.datetime = formatDate(props.datetime);
+    if (props.start_datetime) dates.start = formatDate(props.start_datetime);
+    if (props.end_datetime) dates.end = formatDate(props.end_datetime);
   }
 
   return dates;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,7 @@
 import { format } from 'date-fns';
 
+import { Collection, StacItem } from '@/typings/stac';
+
 export const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd';
 
 export const formatDate = (date: string | Date, formatStr = DEFAULT_DATE_FORMAT): string => {
@@ -9,4 +11,64 @@ export const formatDate = (date: string | Date, formatStr = DEFAULT_DATE_FORMAT)
   } catch (error) {
     throw new Error(error.message);
   }
+};
+
+type Asset = {
+  datetime?: string;
+  created?: string;
+  updated?: string;
+  start_datetime?: string;
+  end_datetime?: string;
+};
+
+type StacData = Collection | StacItem;
+
+export type ExtractedDates = {
+  start: string | null;
+  end: string | null;
+  datetime: string | null;
+  created: string | null;
+  updated: string | null;
+  start_datetime: string | null;
+  end_datetime: string | null;
+};
+
+export const extractDates = (stacData: StacData): ExtractedDates => {
+  const dates: ExtractedDates = {
+    start: null,
+    end: null,
+    datetime: null,
+    created: null,
+    updated: null,
+    start_datetime: null,
+    end_datetime: null,
+  };
+
+  // Handle Collection temporal extent
+  if (stacData.type === 'Collection') {
+    const temporalExtent = stacData?.extent?.temporal?.interval?.[0]; // First interval
+    if (temporalExtent) {
+      dates.start = temporalExtent[0] || null;
+      dates.end = temporalExtent[1] || null;
+    }
+  }
+
+  // Handle Item datetime in properties
+  if (stacData.type === 'Feature') {
+    dates.start = stacData.properties.datetime || stacData.properties.start_datetime || null;
+    dates.end = stacData.properties.end_datetime || null;
+  }
+
+  // Handle assets (in both Collection and Item)
+  if (stacData.assets) {
+    Object.values(stacData.assets).forEach((asset: Asset) => {
+      dates.datetime = asset.datetime || dates.datetime;
+      dates.created = asset.created || dates.created;
+      dates.updated = asset.updated || dates.updated;
+      dates.start_datetime = asset.start_datetime || dates.start_datetime;
+      dates.end_datetime = asset.end_datetime || dates.end_datetime;
+    });
+  }
+
+  return dates;
 };

--- a/src/utils/stacUtils.tsx
+++ b/src/utils/stacUtils.tsx
@@ -116,10 +116,10 @@ export const returnFeatureThumbnail = (feature: StacItem): string => {
 
 // Extract the first non null date value from potential dates
 export const getStacDate = (dates: ExtractedDates): string => {
-  const firstNonNullDate = Object.entries(dates).find(([key, value]) => value !== null);
+  const firstNonNullDate = Object.entries(dates).find(([, value]) => value !== null);
   let date: string;
   if (firstNonNullDate) {
-    const [key, value] = firstNonNullDate;
+    const [, value] = firstNonNullDate;
     date = value;
   } else {
     date = 'No date provided';

--- a/src/utils/stacUtils.tsx
+++ b/src/utils/stacUtils.tsx
@@ -5,7 +5,7 @@ import { TbAxisX } from 'react-icons/tb';
 import { DataPoint } from '@/pages/MapViewer/components/Toolbox/components/ToolboxRow/types';
 import { Collection, StacItem, TemporalExtentObject } from '@/typings/stac';
 
-import { DEFAULT_DATE_FORMAT, formatDate } from './date';
+import { ExtractedDates, extractDates, formatDate } from './date';
 import { titleFromId } from './genericUtils';
 
 /**
@@ -90,16 +90,15 @@ const handleTemporalDataPoints = (
 export const parseFeatureDataPoints = (feature: StacItem): DataPoint[] => {
   // just return the time
   const dataPoints: DataPoint[] = [];
-  const {
-    properties: { datetime },
-  } = feature;
+  const datetime = feature?.properties?.datetime;
 
   if (datetime) {
+    const dates = extractDates(feature);
     dataPoints.push({
       id: `${feature.collection}_datetime`,
       icon: IoTimeOutline,
       alt: 'Time Icon',
-      value: formatDate(datetime, `${DEFAULT_DATE_FORMAT} hh:mm:ss`),
+      value: getStacDate(dates),
       tooltip: 'Datetime',
     });
   }
@@ -113,4 +112,17 @@ export const returnFeatureThumbnail = (feature: StacItem): string => {
     (asset) => asset.roles && asset.roles.includes('thumbnail'),
   );
   return thumbnailAsset?.href || 'https://via.placeholder.com/100';
+};
+
+// Extract the first non null date value from potential dates
+export const getStacDate = (dates: ExtractedDates): string => {
+  const firstNonNullDate = Object.entries(dates).find(([key, value]) => value !== null);
+  let date: string;
+  if (firstNonNullDate) {
+    const [key, value] = firstNonNullDate;
+    date = value;
+  } else {
+    date = 'No date provided';
+  }
+  return date;
 };

--- a/src/utils/stacUtils.tsx
+++ b/src/utils/stacUtils.tsx
@@ -70,19 +70,13 @@ const handleTemporalDataPoints = (
   dataPoints: DataPoint[],
 ) => {
   if (!temporal.interval) return;
+  const dates = extractDates(collection);
+  const date = getStacDate(dates);
   dataPoints.push({
     id: `${collection.id}_temporal`,
     icon: IoTimeOutline,
     alt: 'Time Icon',
-    value:
-      temporal?.interval.length > 0 ? (
-        <div>
-          <div>{formatDate(temporal.interval[0][0])} - </div>
-          <div>{formatDate(temporal.interval[0][1])}</div>
-        </div>
-      ) : (
-        'No date given'
-      ),
+    value: date,
     tooltip: 'Temporal Extent',
   });
 };
@@ -114,15 +108,12 @@ export const returnFeatureThumbnail = (feature: StacItem): string => {
   return thumbnailAsset?.href || 'https://via.placeholder.com/100';
 };
 
-// Extract the first non null date value from potential dates
+// Given all the dates on a STAC object, return the most relevant date.
 export const getStacDate = (dates: ExtractedDates): string => {
-  const firstNonNullDate = Object.entries(dates).find(([, value]) => value !== null);
-  let date: string;
-  if (firstNonNullDate) {
-    const [, value] = firstNonNullDate;
-    date = value;
-  } else {
-    date = 'No date provided';
-  }
+  let date: string = 'No date provided';
+  if (dates.datetime) date = dates.datetime;
+  if (dates.start && dates.end) date = `${dates.start} - ${dates.end}`;
+  if (dates.start && !dates.end) date = `From ${dates.start} onwards`;
+  if (!dates.start && dates.end) date = `Up to ${dates.end}`;
   return date;
 };

--- a/src/utils/stacUtils.tsx
+++ b/src/utils/stacUtils.tsx
@@ -71,7 +71,7 @@ const handleTemporalDataPoints = (
 ) => {
   if (!temporal.interval) return;
   const dates = extractDates(collection);
-  const date = getStacDate(dates);
+  const date = getFormattedSTACDateStr(dates);
   dataPoints.push({
     id: `${collection.id}_temporal`,
     icon: IoTimeOutline,
@@ -92,7 +92,7 @@ export const parseFeatureDataPoints = (feature: StacItem): DataPoint[] => {
       id: `${feature.collection}_datetime`,
       icon: IoTimeOutline,
       alt: 'Time Icon',
-      value: getStacDate(dates),
+      value: getFormattedSTACDateStr(dates),
       tooltip: 'Datetime',
     });
   }
@@ -108,8 +108,8 @@ export const returnFeatureThumbnail = (feature: StacItem): string => {
   return thumbnailAsset?.href || 'https://via.placeholder.com/100';
 };
 
-// Given all the dates on a STAC object, return the most relevant date.
-export const getStacDate = (dates: ExtractedDates): string => {
+// Given all the dates on a STAC object, return the most relevant date as a formatted string.
+export const getFormattedSTACDateStr = (dates: ExtractedDates): string => {
   let date: string = 'No date provided';
   if (dates.datetime) date = dates.datetime;
   if (dates.start && dates.end) date = `${dates.start} - ${dates.end}`;


### PR DESCRIPTION
Dates across the application were not being handled consistently.

Added a method which can go through a STAC item or STAC collection and extract all the dates from the object. It will then pick the first non null date and render this for the object.