### PR TITLE
EODHP-1007 Add pagination and fix typings

### DIFF
--- a/src/components/tree/Tree.scss
+++ b/src/components/tree/Tree.scss
@@ -22,4 +22,9 @@
 
 .branch {
   list-style-type: none;
+  padding: 0;
+}
+
+.leaf {
+  border: 1px solid #00000003;
 }

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -1,4 +1,5 @@
-import folder from '@/assets/icons/folder.png';
+import { MdExpandLess, MdExpandMore } from 'react-icons/md';
+
 import { useCatalogue } from '@/hooks/useCatalogue';
 import ToolboxRow from '@/pages/MapViewer/components/Toolbox/components/ToolboxRow';
 import { fetchFavouritedItems } from '@/services/stac';
@@ -27,9 +28,9 @@ export const TreeNode = ({ node, toggleExpand, expandedNodes, handleLeafClick }:
     const isExpanded = expandedNodes[node.id] ?? false;
 
     return (
-      <li key={node.id}>
+      <li key={node.id} className="leaf">
         <button className="node" onClick={() => toggleExpand(node.id)}>
-          {isExpanded ? '[-]' : '[+]'} {label}
+          {isExpanded ? <MdExpandLess /> : <MdExpandMore />} {label}
         </button>
 
         {isExpanded ? (
@@ -45,7 +46,7 @@ export const TreeNode = ({ node, toggleExpand, expandedNodes, handleLeafClick }:
             ))}
             {node.collections?.map((collection) => {
               // Extract the thumbnail URL from the assets object
-              const thumbnailUrl = collection.assets?.thumbnail?.href ?? folder;
+              const thumbnailUrl = '';
 
               return (
                 <li key={collection.id}>

--- a/src/context/FilterContext/index.tsx
+++ b/src/context/FilterContext/index.tsx
@@ -22,6 +22,8 @@ const initialState: FilterState = {
     },
     aoi: null,
     qualityAssurance: null,
+    resultsPerPage: 10,
+    resultsPage: 1,
   },
 };
 
@@ -76,6 +78,23 @@ const FilterProvider: React.FC<FilterProviderProps> = ({ children }) => {
     });
   };
 
+  // Toolbox Items specific filters
+  // i.e. resultsPage, resultsPerPage, etc.
+  const setResultsPerPage = (resultsPerPage: number) => {
+    setActiveFilters({
+      ...state.activeFilters,
+      resultsPerPage,
+    });
+  };
+
+  const setResultsPage = (resultsPage: number) => {
+    setActiveFilters({
+      ...state.activeFilters,
+      resultsPage,
+    });
+  };
+
+  // General utility functions
   const resetFilters = () =>
     setActiveFilters({
       textQuery: '',
@@ -84,6 +103,9 @@ const FilterProvider: React.FC<FilterProviderProps> = ({ children }) => {
         end: '',
       },
       aoi: null,
+      qualityAssurance: null,
+      resultsPerPage: 10,
+      resultsPage: 1,
     });
 
   const value = {
@@ -97,6 +119,8 @@ const FilterProvider: React.FC<FilterProviderProps> = ({ children }) => {
       setTemporalStartFilter,
       setTemporalEndFilter,
       setAoiFilter,
+      setResultsPerPage,
+      setResultsPage,
       resetFilters,
     },
   };

--- a/src/context/FilterContext/types.ts
+++ b/src/context/FilterContext/types.ts
@@ -21,6 +21,8 @@ export interface FilterContextType {
     setTemporalStartFilter: (start: string) => void;
     setTemporalEndFilter: (end: string) => void;
     setAoiFilter: (geometry: GeoJSONGeometry) => void;
+    setResultsPerPage: (resultsPerPage: number) => void;
+    setResultsPage: (resultsPage: number) => void;
     resetFilters: () => void;
   };
 }
@@ -50,4 +52,6 @@ export interface FilterActiveFilters {
   temporal: Temporal;
   aoi: GeoJSONGeometry;
   qualityAssurance?: string;
+  resultsPerPage?: number;
+  resultsPage?: number;
 }

--- a/src/context/ToolboxContext/index.tsx
+++ b/src/context/ToolboxContext/index.tsx
@@ -73,7 +73,6 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
             activeFilters.temporal.start,
             activeFilters.temporal.end,
           );
-          console.log('Set Selected Collection Items:', items);
           setSelectedCollectionItems(items);
           setCollectionItemsPending(false);
         } catch (error) {
@@ -99,7 +98,6 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
         (activeFilters.resultsPage - 1) * 10,
         activeFilters.resultsPage * 10,
       );
-      console.log('returnResultsPageOutput:', returnResultsPageOutput);
       return returnResultsPageOutput;
     }
     return [];

--- a/src/context/ToolboxContext/index.tsx
+++ b/src/context/ToolboxContext/index.tsx
@@ -91,6 +91,18 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
     state.selectedCollection,
   ]);
 
+  // Inside of selectedCollectionItems there is 100 items.
+  // We only want to return 10 at a time, in relation to the active page the user is on. Ignore the resultsPerPage for now.
+  const returnResultsPage = () => {
+    if (state.selectedCollectionItems?.features) {
+      return state.selectedCollectionItems.features.slice(
+        (activeFilters.resultsPage - 1) * 10,
+        activeFilters.resultsPage * 10,
+      );
+    }
+    return [];
+  };
+
   const value = {
     state,
     actions: {
@@ -115,6 +127,7 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
           payload: selectedCollectionItem,
         });
       },
+      returnResultsPage,
     },
   };
 

--- a/src/context/ToolboxContext/index.tsx
+++ b/src/context/ToolboxContext/index.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useEffect, useReducer } from 'react';
 
-import { FeatureCollection } from 'geojson';
 import { useLocation } from 'react-router-dom';
 
 import { useFilters } from '@/hooks/useFilters';
@@ -48,7 +47,7 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
   const searchParams = new URLSearchParams(search);
   const catalogPath = searchParams.get('catalogPath');
 
-  const setSelectedCollectionItems = (selectedCollectionItems: FeatureCollection) => {
+  const setSelectedCollectionItems = (selectedCollectionItems: ExtendedFeatureCollection) => {
     dispatch({
       type: 'SET_SELECTED_COLLECTION_ITEMS',
       payload: selectedCollectionItems,
@@ -74,6 +73,7 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
             activeFilters.temporal.start,
             activeFilters.temporal.end,
           );
+          console.log('Set Selected Collection Items:', items);
           setSelectedCollectionItems(items);
           setCollectionItemsPending(false);
         } catch (error) {
@@ -95,10 +95,12 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
   // We only want to return 10 at a time, in relation to the active page the user is on. Ignore the resultsPerPage for now.
   const returnResultsPage = () => {
     if (state.selectedCollectionItems?.features) {
-      return state.selectedCollectionItems.features.slice(
+      const returnResultsPageOutput = state.selectedCollectionItems.features.slice(
         (activeFilters.resultsPage - 1) * 10,
         activeFilters.resultsPage * 10,
       );
+      console.log('returnResultsPageOutput:', returnResultsPageOutput);
+      return returnResultsPageOutput;
     }
     return [];
   };
@@ -115,7 +117,7 @@ const ToolboxProvider: React.FC<ToolboxProviderProps> = ({ children }) => {
           payload: selectedCollection,
         });
       },
-      setSelectedCollectionItems: (selectedCollectionItems: FeatureCollection) => {
+      setSelectedCollectionItems: (selectedCollectionItems: ExtendedFeatureCollection) => {
         dispatch({
           type: 'SET_SELECTED_COLLECTION_ITEMS',
           payload: selectedCollectionItems,

--- a/src/context/ToolboxContext/types.ts
+++ b/src/context/ToolboxContext/types.ts
@@ -1,22 +1,11 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import React from 'react';
 
-import { FeatureCollection } from 'geojson';
-
 import { Collection, StacItem } from '@/typings/stac';
-
-export interface ExtendedFeatureCollection extends FeatureCollection {
-  context?: {
-    matched?: number;
-  };
-}
 
 export interface ToolboxState {
   activePage: string;
   selectedCollection: Collection | null;
-  selectedCollectionItems: FeatureCollection;
+  selectedCollectionItems: ExtendedFeatureCollection;
   selectedCollectionItem: StacItem;
   isCollectionItemsPending: boolean;
 }
@@ -24,7 +13,7 @@ export interface ToolboxState {
 export type ToolboxAction =
   | { type: 'SET_ACTIVE_PAGE'; payload: string }
   | { type: 'SET_SELECTED_COLLECTION'; payload: Collection }
-  | { type: 'SET_SELECTED_COLLECTION_ITEMS'; payload: FeatureCollection }
+  | { type: 'SET_SELECTED_COLLECTION_ITEMS'; payload: ExtendedFeatureCollection }
   | { type: 'SET_SELECTED_COLLECTION_ITEM'; payload: StacItem }
   | { type: 'SET_COLLECTION_ITEMS_PENDING'; payload: boolean };
 
@@ -35,8 +24,7 @@ export interface ToolboxContextType {
     setSelectedCollection: (selectedCollection: Collection) => void;
     setSelectedCollectionItems: (selectedCollectionItems: ExtendedFeatureCollection) => void;
     setSelectedCollectionItem: (selectedCollectionItem: StacItem) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    returnResultsPage: () => any;
+    returnResultsPage: () => StacItem[];
   };
 }
 

--- a/src/context/ToolboxContext/types.ts
+++ b/src/context/ToolboxContext/types.ts
@@ -4,6 +4,12 @@ import { FeatureCollection } from 'geojson';
 
 import { Collection, StacItem } from '@/typings/stac';
 
+export interface ExtendedFeatureCollection extends FeatureCollection {
+  context?: {
+    matched?: number;
+  };
+}
+
 export interface ToolboxState {
   activePage: string;
   selectedCollection: Collection | null;
@@ -24,7 +30,7 @@ export interface ToolboxContextType {
   actions: {
     setActivePage: (activePage: string) => void;
     setSelectedCollection: (selectedCollection: Collection) => void;
-    setSelectedCollectionItems: (selectedCollectionItems: FeatureCollection) => void;
+    setSelectedCollectionItems: (selectedCollectionItems: ExtendedFeatureCollection) => void;
     setSelectedCollectionItem: (selectedCollectionItem: StacItem) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     returnResultsPage: () => any;

--- a/src/context/ToolboxContext/types.ts
+++ b/src/context/ToolboxContext/types.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 import React from 'react';
 
 import { FeatureCollection } from 'geojson';

--- a/src/context/ToolboxContext/types.ts
+++ b/src/context/ToolboxContext/types.ts
@@ -26,6 +26,8 @@ export interface ToolboxContextType {
     setSelectedCollection: (selectedCollection: Collection) => void;
     setSelectedCollectionItems: (selectedCollectionItems: FeatureCollection) => void;
     setSelectedCollectionItem: (selectedCollectionItem: StacItem) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    returnResultsPage: () => any;
   };
 }
 

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 import ResponsivePagination from 'react-responsive-pagination';
 
 import { useFilters } from '@/hooks/useFilters';

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -26,9 +26,7 @@ const ToolboxItems = () => {
   }
 
   const returnTotalPages = () => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (selectedCollectionItems?.context) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return Math.ceil(selectedCollectionItems.context.matched / activeFilters.resultsPerPage);
     }
     return 0;

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import ResponsivePagination from 'react-responsive-pagination';
 
 import { useFilters } from '@/hooks/useFilters';

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -26,7 +26,9 @@ const ToolboxItems = () => {
   }
 
   const returnTotalPages = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (selectedCollectionItems?.context) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return Math.ceil(selectedCollectionItems.context.matched / activeFilters.resultsPerPage);
     }
     return 0;

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/index.tsx
@@ -17,7 +17,7 @@ const ToolboxItems = () => {
   } = useToolbox();
 
   const {
-    state: { activeFilters }, // activeFilters.resultsPage
+    state: { activeFilters },
     actions: { setResultsPage },
   } = useFilters();
 
@@ -57,7 +57,6 @@ const ToolboxItems = () => {
           current={activeFilters.resultsPage}
           total={returnTotalPages()}
           onPageChange={(e) => {
-            console.log('Page Change:', e);
             setResultsPage(e);
           }}
         />

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxItems/styles.scss
@@ -6,7 +6,7 @@
 
 .toolbox__items {
   overflow-y: auto;
-  height: calc(100% - 50px);
+  height: calc(100% - 150px);
 }
 
 .no-items {
@@ -19,9 +19,20 @@
 .button-wrapper {
   display: flex;
   justify-content: space-between;
+  margin-top: 0.25rem;
 
   & .purchase-btn {
     padding: 0.5rem;
+  }
+
+  button {
+    background-color: white;
+    border-radius: 5px;
+    padding: 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    border: 1px solid rgb(222 226 230);
+    color: #2a3559;
   }
 }
 

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/index.tsx
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/index.tsx
@@ -1,3 +1,4 @@
+import placeholder from '@/assets/placeholders/100.png';
 import { titleFromId } from '@/utils/genericUtils';
 
 import { ToolboxItemProps } from './types.js';
@@ -13,7 +14,7 @@ const ToolboxRow = ({ thumbnail, title, dataPoints, onClick, children }: Toolbox
           src={thumbnail}
           onError={(e) => {
             console.error('Error loading image:', thumbnail, e);
-            e.currentTarget.src = 'https://via.placeholder.com/100';
+            e.currentTarget.src = placeholder;
           }}
         />
       </div>

--- a/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/components/ToolboxRow/styles.scss
@@ -23,7 +23,7 @@
     img {
       height: 100px;
       width: 100px;
-      border: 1px solid black;
+      border: 1px solid rgb(163 163 163);
       object-fit: cover;
     }
   }

--- a/src/pages/MapViewer/components/Toolbox/styles.scss
+++ b/src/pages/MapViewer/components/Toolbox/styles.scss
@@ -36,7 +36,7 @@
   }
 
   &__header {
-    height: 50px;
+    height: 150px;
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -46,13 +46,46 @@
 
     &-title {
       display: flex;
-      align-items: flex-end;
+      align-items: center;
+      font-size: 1.5rem;
       font-weight: bold;
+      color: $primary-colour;
       justify-content: center;
+      text-transform: uppercase;
+    }
+
+    &-error {
+      display: flex;
+      justify-content: center;
+      color: red;
     }
 
     &-back {
       cursor: pointer;
+      background-color: #2a3559;
+      width: fit-content;
+      padding: 0.5rem 1.25rem;
+      margin: 0.5rem 0;
+      color: white;
+      font-weight: bold;
+
+      span {
+        font-size: 0.95rem;
+      }
+    }
+
+    .pagination .page-link {
+      color: $primary-colour;
+    }
+
+    .pagination .active > .page-link {
+      background-color: #2a3559 !important;
+      border-color: #3f4d7d;
+      color: white;
+    }
+
+    .pagination {
+      padding-bottom: 1rem;
     }
   }
 }

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { FeatureCollection } from 'geojson';
 import { GeoJSONGeometry } from 'ol/format/GeoJSON';
 
 import hgb from '@/assets/placeholders/hgb.png';
@@ -59,12 +58,6 @@ export const getStacCollections = async (
     throw error;
   }
 };
-
-export interface ExtendedFeatureCollection extends FeatureCollection {
-  context?: {
-    matched?: number;
-  };
-}
 
 // In the future we are going to use `cql2-json`, this item search is temporary
 export const getStacItems = async (

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -60,6 +60,12 @@ export const getStacCollections = async (
   }
 };
 
+export interface ExtendedFeatureCollection extends FeatureCollection {
+  context?: {
+    matched?: number;
+  };
+}
+
 // In the future we are going to use `cql2-json`, this item search is temporary
 export const getStacItems = async (
   privateCatalog: string,
@@ -67,7 +73,7 @@ export const getStacItems = async (
   geometry: GeoJSONGeometry,
   startDate: string,
   endDate: string,
-): Promise<FeatureCollection> => {
+): Promise<ExtendedFeatureCollection> => {
   const itemsUrl = privateCatalog
     ? `${import.meta.env.VITE_STAC_ENDPOINT}/catalogs/${privateCatalog}/search`
     : `${import.meta.env.VITE_STAC_ENDPOINT}/search`;

--- a/src/services/stac/index.tsx
+++ b/src/services/stac/index.tsx
@@ -73,7 +73,7 @@ export const getStacItems = async (
 
   const data = {
     collections: [collection.id],
-    limit: 100,
+    limit: 200,
     catalog_paths: [getStacCatalogUrl(collection)],
     intersects: geometry,
   };

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -1,4 +1,7 @@
 // Credit https://github.com/blacha/stac-ts for the STAC typings
+import { FeatureCollection } from 'geojson';
+
+import { StacItem } from './stac';
 
 export type StacVersion = '1.0.0';
 export type StacExtensions = string[];
@@ -104,3 +107,12 @@ export type Temporal = {
   start: string;
   end: string;
 };
+
+declare global {
+  interface ExtendedFeatureCollection extends FeatureCollection {
+    context?: {
+      matched?: number;
+    };
+    features: StacItem[];
+  }
+}


### PR DESCRIPTION
The site was freezing up/going slow when trying to load 100 `<ToolboxItem/>`'s in a list.

This uses pagination to cycle through the list, only showing 10 at a time.

Also fixed extended the FeatureCollection typing to correctly include a list of stac items within it.